### PR TITLE
Node.js 18 LTS

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:18
 
 # Create app directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ your local machine for development and testing purposes.
 Requirements for the software and other tools to build, test and push
 
 - [Git](https://git-scm.com/) - Version control system
-- [NodeJS](https://nodejs.org/) - Cross-platform JavaScript runtime environment
+- [NodeJS](https://nodejs.org/) 18.12+ - Cross-platform JavaScript runtime environment
 - [yarn](https://yarnpkg.com/) - Package manager
 
 ### Install

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
       "unicorn/prefer-top-level-await": "warn",
       "n/prefer-global/process": "off"
     }
+  },
+  "engines": {
+    "node": ">=18.12"
   }
 }


### PR DESCRIPTION
Passage à Node.js 18 LTS (18.12+) comme version minimale (la 20 LTS sort dans un mois mais on va pas être pressés).
Utilisation de Node 18 dans le Dockerfile et adaptation de la configuration GitHub Actions pour commencer à faire tourner la version 20 (et supprimer la 16 qui a terminé sa vie il y a une semaine).