### PR TITLE
fix(auth): add missing user data in access token

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -122,6 +122,7 @@ function buildOAuthCallbackUrl(req, shouldEncode = false, path) {
 
 async function getWordpressUser(oauthAccessToken) {
   const wordpressUser = await getUserFromOAuthAccessToken(oauthAccessToken)
+
   const {
     ID: id,
     user_email: email,
@@ -214,19 +215,13 @@ export async function refreshTokens(jwtRefreshToken) {
   const oauthRefreshToken = await verifyRefreshToken(jwtRefreshToken)
   const {access_token: newOauthAccessToken, refresh_token: newOauthRefreshToken} = await refreshOAuthTokens(oauthRefreshToken)
 
-  const wordpressUser = await getWordpressUser(newOauthAccessToken)
-  const {
-    ID: id,
-    user_email: email,
-    display_name: name,
-    user_roles: roles,
-  } = wordpressUser
+  const user = await getWordpressUser(newOauthAccessToken)
 
-  const newAccessToken = createAccessToken(id, name, email, roles)
+  const newAccessToken = createAccessToken(user.id, user.name, user.email, user.roles)
   const newRefreshToken = createRefreshToken(newOauthRefreshToken)
 
   return {
-    user: wordpressUser,
+    user,
     accessToken: newAccessToken,
     refreshToken: newRefreshToken
   }


### PR DESCRIPTION
Les données de l'utilisateur (comme l'id, l'email, les rôles…) n'étaient pas inscrit dans l'accessToken lorsqu'on le rafraîchissait