### PR TITLE
Envoi des notifications à l'aide d'un script (planifié) plutôt que via un appel d'API

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ Or if you want some live-reload:
 yarn dev
 ```
 
+## Useful scripts
+
+### Send daily notification emails
+
+Tickets bundles a script to send notification emails to members.
+You should consider executing this script once a day, at the end of the day.
+
+```bash
+node scripts/send-notification-emails.js
+```
+
+Pro-tips: use `crontab -e`
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,10 +1,7 @@
-import {sub, add, isValid} from 'date-fns'
-import {chain, pick} from 'lodash-es'
+import {sub, isValid} from 'date-fns'
+import {pick} from 'lodash-es'
 
 import mongo from './util/mongo.js'
-import {sendMail} from './util/sendmail.js'
-import renderFinAbonnement from './emails/fin-abonnement.js'
-import renderPlusDeTickets from './emails/plus-de-tickets.js'
 
 import * as Member from './models/member.js'
 import * as Presence from './models/presence.js'
@@ -151,48 +148,6 @@ export async function updatePresence(req, res) {
 
   // Mise à jour de la balance de tickets
   await Member.recomputeBalance(userId)
-
-  res.sendStatus(200)
-}
-
-export async function notify(req, res) {
-  // On commence par déterminer les utilisateurs en fin d'abonnement
-  const expiringAboStartDate = add(sub(new Date(), {months: 1}), {days: 1}).toISOString().slice(0, 10)
-  const candidateEndOfAboUsers = await mongo.db.collection('users')
-    .find({'profile.abos': {$elemMatch: {aboStart: expiringAboStartDate}}})
-    .project({_id: 0, 'emails.address': 1, 'profile.abos': 1})
-    .toArray()
-  const tomorrow = add(new Date(), {days: 1}).toISOString().slice(0, 10)
-  const oneMonthBeforeTomorrow = sub(new Date(tomorrow), {months: 1}).toISOString().slice(0, 10)
-  const endOfAboUsers = candidateEndOfAboUsers.filter(user => {
-    const hasAboForTomorrow = user.profile.abos.some(
-      abo => oneMonthBeforeTomorrow < abo.aboStart && abo.aboStart <= tomorrow
-    )
-    return !hasAboForTomorrow
-  })
-  const endOfAboEmails = chain(endOfAboUsers).map('emails').flatten().value()
-  await Promise.all(endOfAboEmails.map(async email => sendMail(
-    renderFinAbonnement(),
-    [email]
-  )))
-
-  // Ensuite on s'occupe des utilisateurs qui n'ont plus de tickets
-  const yesterday = sub(new Date(), {days: 1}).toISOString().slice(0, 10)
-  const todayUsers = await mongo.db.collection('users')
-    .find({'profile.heartbeat': {$gt: yesterday}})
-    .project({_id: 0, 'emails.address': 1, profile: 1})
-    .toArray()
-  const today = (new Date()).toISOString().slice(0, 10)
-  const oneMonthAgo = sub(new Date(), {months: 1}).toISOString().slice(0, 10)
-  const outOfTicketsUsers = todayUsers.filter(user => {
-    const isDuringAbo = user.profile.abos.some(abo => oneMonthAgo < abo.aboStart && abo.aboStart <= today)
-    return !isDuringAbo && user.profile.balance <= 0
-  })
-  const outOfTicketsEmails = chain(outOfTicketsUsers).map('emails').flatten().value()
-  await Promise.all(outOfTicketsEmails.map(async email => sendMail(
-    renderPlusDeTickets(),
-    [email]
-  )))
 
   res.sendStatus(200)
 }

--- a/scripts/send-notification-emails.js
+++ b/scripts/send-notification-emails.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import 'dotenv/config.js'
+
+import {sub, add} from 'date-fns'
+import {chain} from 'lodash-es'
+
+import mongo from '../lib/util/mongo.js'
+import {sendMail} from '../lib/util/sendmail.js'
+import renderFinAbonnement from '../lib/emails/fin-abonnement.js'
+import renderPlusDeTickets from '../lib/emails/plus-de-tickets.js'
+
+await mongo.connect()
+
+// On commence par déterminer les utilisateurs en fin d'abonnement
+const expiringAboStartDate = add(sub(new Date(), {months: 1}), {days: 1}).toISOString().slice(0, 10)
+const candidateEndOfAboUsers = await mongo.db.collection('users')
+  .find({'profile.abos': {$elemMatch: {aboStart: expiringAboStartDate}}})
+  .project({_id: 0, 'emails.address': 1, 'profile.abos': 1})
+  .toArray()
+const tomorrow = add(new Date(), {days: 1}).toISOString().slice(0, 10)
+const oneMonthBeforeTomorrow = sub(new Date(tomorrow), {months: 1}).toISOString().slice(0, 10)
+const endOfAboUsers = candidateEndOfAboUsers.filter(user => {
+  const hasAboForTomorrow = user.profile.abos.some(
+    abo => oneMonthBeforeTomorrow < abo.aboStart && abo.aboStart <= tomorrow
+  )
+  return !hasAboForTomorrow
+})
+const endOfAboEmails = chain(endOfAboUsers).map('emails').flatten().value()
+await Promise.all(endOfAboEmails.map(async email => sendMail(
+  renderFinAbonnement(),
+  [email]
+)))
+
+// Ensuite on s'occupe des utilisateurs qui n'ont plus de tickets
+const yesterday = sub(new Date(), {days: 1}).toISOString().slice(0, 10)
+const todayUsers = await mongo.db.collection('users')
+  .find({'profile.heartbeat': {$gt: yesterday}})
+  .project({_id: 0, 'emails.address': 1, profile: 1})
+  .toArray()
+const today = (new Date()).toISOString().slice(0, 10)
+const oneMonthAgo = sub(new Date(), {months: 1}).toISOString().slice(0, 10)
+const outOfTicketsUsers = todayUsers.filter(user => {
+  const isDuringAbo = user.profile.abos.some(abo => oneMonthAgo < abo.aboStart && abo.aboStart <= today)
+  return !isDuringAbo && user.profile.balance <= 0
+})
+const outOfTicketsEmails = chain(outOfTicketsUsers).map('emails').flatten().value()
+await Promise.all(outOfTicketsEmails.map(async email => sendMail(
+  renderPlusDeTickets(),
+  [email]
+)))
+
+await mongo.disconnect()
+

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ import statsRoutes from './lib/routes/stats.js'
 import * as Member from './lib/models/member.js'
 
 import cache from './lib/util/cache.js'
-import {coworkersNow, getAllMembers, getMemberInfos, getMemberPresences, getMemberTickets, getMemberSubscriptions, heartbeat, getMacAddresses, getMacAddressesLegacy, updatePresence, notify, purchaseWebhook, forceWordpressSync, getUsersStats, getCurrentMembers, getVotingMembers, updateMemberMacAddresses} from './lib/api.js'
+import {coworkersNow, getAllMembers, getMemberInfos, getMemberPresences, getMemberTickets, getMemberSubscriptions, heartbeat, getMacAddresses, getMacAddressesLegacy, updatePresence, purchaseWebhook, forceWordpressSync, getUsersStats, getCurrentMembers, getVotingMembers, updateMemberMacAddresses} from './lib/api.js'
 import {ensureToken, multiAuth, authRouter} from './lib/auth.js'
 import {ping} from './lib/ping.js'
 import {precomputeStats} from './lib/stats.js'
@@ -111,7 +111,6 @@ app.post('/api/heartbeat', express.urlencoded({extended: false}), w(ensureToken)
 app.get('/api/mac', w(multiAuth), w(getMacAddresses)) // Unused
 app.post('/api/mac', express.urlencoded({extended: false}), w(ensureToken), w(getMacAddressesLegacy))
 app.post('/api/presence', express.urlencoded({extended: false}), w(ensureToken), w(updatePresence))
-app.post('/api/notify', express.urlencoded({extended: false}), w(ensureToken), w(notify))
 
 /* Webhooks */
 


### PR DESCRIPTION
Actuellement l'envoi des notifications se fait via un appel d'API `/api/notify` déclenché par `presences`.
Désormais c'est une commande qui peut être planifiée.

Cette PR n'a pas l'ambition de revoir ce système, qui néanmoins le mérite.