### PR TITLE
Move MAC addresses to new device model

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,5 @@
 import {sub, isValid} from 'date-fns'
-import {pick} from 'lodash-es'
+import {pick, keyBy} from 'lodash-es'
 
 import mongo from './util/mongo.js'
 
@@ -8,6 +8,7 @@ import * as Presence from './models/presence.js'
 import * as Ticket from './models/ticket.js'
 import * as Subscription from './models/subscription.js'
 import * as Membership from './models/membership.js'
+import * as Device from './models/device.js'
 
 function formatDate(date) {
   return date.toISOString().slice(0, 10)
@@ -55,7 +56,7 @@ export async function getMemberTickets(req, res) {
 }
 
 export async function updateMemberMacAddresses(req, res) {
-  const macAddresses = await Member.updateMemberMacAddresses(req.rawUser._id, req.body)
+  const macAddresses = await Device.assignMacAddressesToMember(req.rawUser._id, req.body)
   res.send(macAddresses)
 }
 
@@ -67,30 +68,35 @@ export async function forceWordpressSync(req, res) {
 
 export async function heartbeat(req, res) {
   const macAddresses = req.body.macAddresses.split(',')
-  const now = (new Date()).toISOString()
-
-  // Pour le moment on garde updateMany car on n'a pas encore d'unicité dans la base.
-  await mongo.db.collection('users').updateMany(
-    {'profile.macAddresses': {$in: macAddresses}},
-    {$set: {'profile.heartbeat': now}}
-  )
-
+  await Device.heartbeatDevicesByMacAddresses(macAddresses)
   res.sendStatus(200)
 }
 
 export async function getMacAddressesLegacy(req, res) {
-  const users = await mongo.db.collection('users').aggregate([
-    {$unwind: '$profile.macAddresses'},
-    {$match: {'profile.macAddresses': {$ne: null}}},
-    {$project: {'profile.firstName': 1, 'profile.lastName': 1, emails: 1, 'profile.macAddresses': 1}}
-  ]).toArray()
+  const assignedDevices = await Device.getAssignedDevices()
+  const indexedDevices = keyBy(assignedDevices, 'member')
 
-  const rows = users.map(user => ([
-    user.profile.macAddresses.toUpperCase(),
-    user.emails[0].address,
-    user.profile.firstName,
-    user.profile.lastName
-  ]))
+  const members = await mongo.db.collection('users')
+    .find({'profile.firstName': 1, 'profile.lastName': 1, emails: 1})
+    .project()
+    .toArray()
+
+  const rows = []
+
+  for (const member of members) {
+    const memberDevices = indexedDevices[member._id]
+
+    if (memberDevices) {
+      for (const device of memberDevices) {
+        rows.push([
+          device.macAddress.toUpperCase(),
+          member.emails[0].address,
+          member.profile.firstName,
+          member.profile.lastName
+        ])
+      }
+    }
+  }
 
   res.type('text/csv').send(rows.map(row => row.join('\t')).join('\n'))
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -95,19 +95,6 @@ export async function getMacAddressesLegacy(req, res) {
   res.type('text/csv').send(rows.map(row => row.join('\t')).join('\n'))
 }
 
-export async function getMacAddresses(req, res) {
-  const rows = await mongo.db.collection('users').aggregate([
-    {$unwind: '$profile.macAddresses'},
-    {$match: {'profile.macAddresses': {$ne: null}}},
-    {$project: {_id: 1, 'profile.macAddresses': 1}}
-  ]).toArray()
-
-  res.send(rows.map(row => ({
-    userId: row._id,
-    macAddress: row.profile.macAddresses.toUpperCase()
-  })))
-}
-
 export async function updatePresence(req, res) {
   if (!req.body.date || req.body.date.length !== 10 || !isValid(new Date(req.body.date))) {
     return res.sendStatus(400)

--- a/lib/models/device.js
+++ b/lib/models/device.js
@@ -73,8 +73,10 @@ function checkMacAddresseList(macAddresses) {
     .uniq()
     .value()
 
-  if (cleanedMacAddresses.some(macAddress => !isMacAddress(macAddress))) {
-    throw createHttpError(400, 'Invalid MAC address')
+  const invalidMacAddress = cleanedMacAddresses.find(macAddress => !isMacAddress(macAddress))
+
+  if (invalidMacAddress) {
+    throw createHttpError(400, `Invalid MAC address: ${invalidMacAddress}`)
   }
 
   return cleanedMacAddresses

--- a/lib/models/device.js
+++ b/lib/models/device.js
@@ -60,7 +60,7 @@ export async function heartbeatDevicesByMacAddresses(macAddresses) {
 }
 
 function isMacAddress(value) {
-  return /^([\da-f]{2}:){5}([\da-f]{2})$/.test(value)
+  return /^([\dA-F]{2}:){5}([\dA-F]{2})$/.test(value)
 }
 
 function checkMacAddresseList(macAddresses) {

--- a/lib/models/device.js
+++ b/lib/models/device.js
@@ -7,6 +7,16 @@ import * as Member from './member.js'
 export async function assignMacAddressesToMember(memberId, macAddresses) {
   const cleanedMacAddresses = checkMacAddresseList(macAddresses)
 
+  // We check that all devices are not already assigned to another member
+  const alreadyAssignedDevices = await mongo.db.collection('devices').find({
+    member: {$ne: memberId},
+    macAddress: {$in: cleanedMacAddresses}
+  }).toArray()
+
+  if (alreadyAssignedDevices.length > 0) {
+    throw createHttpError(409, 'Some devices are already assigned to another member')
+  }
+
   // We remove all devices from this member that are not in the list
   await mongo.db.collection('devices').updateMany(
     {member: memberId, macAddress: {$nin: cleanedMacAddresses}},

--- a/lib/models/device.js
+++ b/lib/models/device.js
@@ -1,0 +1,71 @@
+import {chain} from 'lodash-es'
+import createHttpError from 'http-errors'
+import mongo from '../util/mongo.js'
+
+import * as Member from './member.js'
+
+export async function assignMacAddressesToMember(memberId, macAddresses) {
+  const cleanedMacAddresses = checkMacAddresseList(macAddresses)
+
+  // We remove all devices from this member that are not in the list
+  await mongo.db.collection('devices').updateMany(
+    {member: memberId, macAddress: {$nin: cleanedMacAddresses}},
+    {$set: {member: null}}
+  )
+
+  // We update or add all devices from the list
+  await Promise.all(cleanedMacAddresses.map(async macAddress => {
+    await mongo.db.collection('devices').updateOne(
+      {macAddress},
+      {$set: {member: memberId}},
+      {upsert: true}
+    )
+  }))
+
+  return getMacAddressesOfMember(memberId)
+}
+
+export async function getMacAddressesOfMember(memberId) {
+  return mongo.db.collection('devices').distinct('macAddress', {member: memberId})
+}
+
+export async function getAssignedDevices() {
+  return mongo.db.collection('devices').find({member: {$ne: null}}).toArray()
+}
+
+export async function heartbeatDevicesByMacAddresses(macAddresses) {
+  const now = new Date()
+  const cleanedMacAddresses = checkMacAddresseList(macAddresses)
+
+  await mongo.db.collection('devices').updateMany(
+    {macAddress: {$in: cleanedMacAddresses}},
+    {$set: {heartbeat: now}}
+  )
+
+  const memberIds = await mongo.db.collection('devices').distinct('member', {
+    macAddress: {$in: cleanedMacAddresses}
+  })
+
+  await Member.heartbeatMembers(memberIds, now)
+}
+
+function isMacAddress(value) {
+  return /^([\da-f]{2}:){5}([\da-f]{2})$/.test(value)
+}
+
+function checkMacAddresseList(macAddresses) {
+  if (!Array.isArray(macAddresses) || macAddresses.some(macAddress => typeof macAddress !== 'string')) {
+    throw createHttpError(400, 'macAddresses must be an array of strings')
+  }
+
+  const cleanedMacAddresses = chain(macAddresses)
+    .map(macAddress => macAddress.trim().toUpperCase())
+    .uniq()
+    .value()
+
+  if (cleanedMacAddresses.some(macAddress => !isMacAddress(macAddress))) {
+    throw createHttpError(400, 'Invalid MAC address')
+  }
+
+  return cleanedMacAddresses
+}

--- a/lib/models/member.js
+++ b/lib/models/member.js
@@ -1,13 +1,14 @@
-import {uniq, maxBy, sumBy, sortBy, chain, pick} from 'lodash-es'
+import {maxBy, sumBy, sortBy, chain, pick} from 'lodash-es'
 import {customAlphabet} from 'nanoid'
 import {sub} from 'date-fns'
-import createHttpError from 'http-errors'
 
 import mongo from '../util/mongo.js'
 import {getUser as getWpUser} from '../util/wordpress.js'
 
 import {convertDateFormat} from '../dates.js'
 import {computeSubcriptionEndDate, computeBalance} from '../calc.js'
+
+import * as Device from './device.js'
 
 const nanoid = customAlphabet('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz')
 
@@ -46,7 +47,9 @@ export async function getUserById(id) {
 
 export async function getMemberById(memberId) {
   const user = await getUserById(memberId)
-  return computeMemberFromUser(user, {withAbos: true, withActivity: true, withMacAddresses: true})
+  const member = computeMemberFromUser(user, {withAbos: true, withActivity: true})
+  member.macAddresses = await Device.getMacAddressesOfMember(memberId)
+  return member
 }
 
 export async function getCurrentMembers(delayInMinutes = 10) {
@@ -69,23 +72,6 @@ export async function getVotingMembers(minActivity = 20) {
     .map(u => pick(u, 'firstName', 'lastName', 'email', 'activity', 'lastMembership', 'balance'))
     .sortBy(u => -u.activity)
     .value()
-}
-
-export async function updateMemberMacAddresses(memberId, macAddresses) {
-  if (!Array.isArray(macAddresses)) {
-    throw createHttpError(400, 'macAddresses must be an array')
-  }
-
-  if (macAddresses.some(mac => !isMacAddress(mac))) {
-    throw createHttpError(400, 'macAddresses must contain only valid mac addresses')
-  }
-
-  const cleanedMacAddresses = uniq(macAddresses.map(macAddress => macAddress.toUpperCase()))
-
-  await mongo.db.collection('users')
-    .updateOne({_id: memberId}, {$set: {'profile.macAddresses': cleanedMacAddresses}})
-
-  return cleanedMacAddresses
 }
 
 export async function recomputeBalance(memberId) {
@@ -209,7 +195,6 @@ export async function createUser({wpUserId, firstName, lastName, birthDate, emai
       presences: [],
       abos: [],
       memberships: [],
-      macAddresses: [],
       firstName,
       lastName,
       birthDate,
@@ -221,6 +206,17 @@ export async function createUser({wpUserId, firstName, lastName, birthDate, emai
 
   await mongo.db.collection('users').insertOne(user)
   return user
+}
+
+export async function heartbeatMembers(memberIds, referenceDate) {
+  if (!referenceDate) {
+    throw new Error('Missing referenceDate')
+  }
+
+  await mongo.db.collection('users').updateMany(
+    {_id: {$in: memberIds}},
+    {$set: {'profile.heartbeat': referenceDate.toISOString()}}
+  )
 }
 
 /* Helpers */
@@ -304,13 +300,5 @@ export function computeMemberFromUser(user, options = {}) {
     member.abos = abos
   }
 
-  if (options.withMacAddresses) {
-    member.macAddresses = (user.profile.macAddresses || []).filter(mac => isMacAddress(mac)) // This filter is temporary
-  }
-
   return member
-}
-
-function isMacAddress(string) {
-  return /^([\da-f]{2}:){5}[\da-f]{2}$/i.test(string)
 }

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -6,6 +6,13 @@ class Mongo {
     this.client = new MongoClient(connectionString || process.env.MONGODB_URL || 'mongodb://localhost:27017')
     await this.client.connect()
     this.db = this.client.db(process.env.MONGODB_DBNAME || 'tickets')
+    await this.createIndexes()
+  }
+
+  async createIndexes() {
+    await this.db.collection('devices').createIndex({macAddress: 1}, {unique: true})
+    await this.db.collection('devices').createIndex({member: 1})
+    await this.db.collection('devices').createIndex({heartbeat: 1})
   }
 
   disconnect(force) {

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ import statsRoutes from './lib/routes/stats.js'
 import * as Member from './lib/models/member.js'
 
 import cache from './lib/util/cache.js'
-import {coworkersNow, getAllMembers, getMemberInfos, getMemberPresences, getMemberTickets, getMemberSubscriptions, heartbeat, getMacAddresses, getMacAddressesLegacy, updatePresence, purchaseWebhook, forceWordpressSync, getUsersStats, getCurrentMembers, getVotingMembers, updateMemberMacAddresses} from './lib/api.js'
+import {coworkersNow, getAllMembers, getMemberInfos, getMemberPresences, getMemberTickets, getMemberSubscriptions, heartbeat, getMacAddressesLegacy, updatePresence, purchaseWebhook, forceWordpressSync, getUsersStats, getCurrentMembers, getVotingMembers, updateMemberMacAddresses} from './lib/api.js'
 import {ensureToken, multiAuth, authRouter} from './lib/auth.js'
 import {ping} from './lib/ping.js'
 import {precomputeStats} from './lib/stats.js'
@@ -108,7 +108,6 @@ app.get('/api/current-users', w(ensureToken), w(getCurrentMembers))
 /* Presences */
 
 app.post('/api/heartbeat', express.urlencoded({extended: false}), w(ensureToken), w(heartbeat))
-app.get('/api/mac', w(multiAuth), w(getMacAddresses)) // Unused
 app.post('/api/mac', express.urlencoded({extended: false}), w(ensureToken), w(getMacAddressesLegacy))
 app.post('/api/presence', express.urlencoded({extended: false}), w(ensureToken), w(updatePresence))
 

--- a/server.js
+++ b/server.js
@@ -50,7 +50,7 @@ app.param('userId', w(async (req, res, next) => {
   // Not all users have a wordpressId
   if (!req.rawUser && /^\d+$/.test(userId)) {
     const wordpressId = Number.parseInt(userId, 10)
-    req.rawUser = await Member.getUserByWordpressId({wpUserId: wordpressId})
+    req.rawUser = await Member.getUserByWordpressId(wordpressId)
   }
 
   if (!req.rawUser) {


### PR DESCRIPTION
We create a new `devices` collection with the following document attributes:
- `_id`: internal MongoDB document ID (never used directly)
- `macAddress`: MAC address (string, unique key)
- `member`: member id (string, optional)
- `heartbeat`: last heartbeat got by the probe (date, optional)

Existing features are adapted to use the new model:
- Update member MAC addresses
- List MAC addresses <> member for _presences_
- Heartbeat propagation for _presences_

We also drop an unused route (`GET /api/mac`).

✅ NO CHANGES ON ACTUAL API ROUTES ✅

Why?

- Simplifying `users` collection
- Per-device heartbeat (useful information to cleanup member devices)
- A device cannot be assigned to more than one member anymore