### PR TITLE
Move "presences" to member activity model

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,14 +1,15 @@
-import {sub, isValid} from 'date-fns'
-import {pick, groupBy} from 'lodash-es'
+import {sub} from 'date-fns'
+import {keyBy, groupBy, chain} from 'lodash-es'
 
 import mongo from './util/mongo.js'
 
 import * as Member from './models/member.js'
-import * as Presence from './models/presence.js'
 import * as Ticket from './models/ticket.js'
 import * as Subscription from './models/subscription.js'
 import * as Membership from './models/membership.js'
 import * as Device from './models/device.js'
+import * as Activity from './models/activity.js'
+import createHttpError from 'http-errors'
 
 function formatDate(date) {
   return date.toISOString().slice(0, 10)
@@ -40,9 +41,18 @@ export async function getMemberInfos(req, res) {
   res.send(member)
 }
 
+export async function getMemberActivity(req, res) {
+  const activity = await Activity.getMemberActivity(req.rawUser._id)
+  res.send(activity)
+}
+
 export async function getMemberPresences(req, res) {
-  const presences = await Presence.getMemberPresences(req.rawUser._id)
-  res.send(presences)
+  const activity = await Activity.getMemberActivity(req.rawUser._id)
+  res.send(activity.map(item => ({
+    date: item.date,
+    amount: item.value,
+    type: item.type === 'subscription' ? 'A' : 'T'
+  })))
 }
 
 export async function getMemberSubscriptions(req, res) {
@@ -102,42 +112,20 @@ export async function getMacAddressesLegacy(req, res) {
 }
 
 export async function updatePresence(req, res) {
-  if (!req.body.date || req.body.date.length !== 10 || !isValid(new Date(req.body.date))) {
-    return res.sendStatus(400)
-  }
-
-  if (!['0.5', '1.0'].includes(req.body.amount)) {
-    return res.sendStatus(400)
-  }
-
   if (!req.body.email) {
-    return res.sendStatus(400)
+    throw createHttpError(400, 'Missing email')
   }
 
   const {date, email} = req.body
-  const amount = Number.parseFloat(req.body.amount)
+  const value = Number.parseFloat(req.body.amount)
 
   const userId = await Member.getUserIdByEmail(email)
 
   if (!userId) {
-    return res.sendStatus(400)
+    throw createHttpError(404, 'Member not found')
   }
 
-  const {matchedCount} = await mongo.db.collection('users').updateOne(
-    {_id: userId, 'profile.presences': {$elemMatch: {date}}},
-    {$set: {'profile.presences.$.amount': amount}}
-  )
-
-  if (!matchedCount) {
-    await mongo.db.collection('users').updateOne(
-      {_id: userId},
-      {
-        $push: {
-          'profile.presences': {date, amount}
-        }
-      }
-    )
-  }
+  await Activity.updateMemberActivity(userId, date, value)
 
   // Mise à jour de la balance de tickets
   await Member.recomputeBalance(userId)
@@ -211,75 +199,72 @@ export async function getUsersStats(req, res) {
     : 'all-time'
 
   const aggregateSteps = [
-    {$unwind: '$profile.presences'}
   ]
 
   if (req.query.from || req.query.to) {
     const dateQuery = {}
 
     if (req.query.from) {
-      dateQuery.$gt = req.query.from
+      dateQuery.$gte = req.query.from
     }
 
     if (req.query.to) {
-      dateQuery.$lt = req.query.to
+      dateQuery.$lte = req.query.to
     }
 
     aggregateSteps.push({
-      $match: {
-        'profile.presences.date': dateQuery
-      }
+      $match: {date: dateQuery}
     })
   }
 
   if (period !== 'all-time') {
     const numDays = Number.parseInt(period.split('-')[1], 10)
     aggregateSteps.push({
-      $match: {
-        'profile.presences.date': {$gt: formatDate(sub(new Date(), {days: numDays}))}
-      }
+      $match: {date: {$gte: formatDate(sub(new Date(), {days: numDays}))}}
     })
   }
 
   aggregateSteps.push(
     {
       $group: {
-        _id: '$_id',
-        emails: {$first: '$emails'},
-        createdAt: {$first: '$createdAt'},
-        wpUserId: {$first: '$wpUserId'},
-        firstName: {$first: '$profile.firstName'},
-        lastName: {$first: '$profile.lastName'},
-        presencesConso: {$sum: '$profile.presences.amount'},
+        _id: '$member',
+        presencesConso: {$sum: '$value'},
         presencesJours: {$sum: 1}
       }
-    },
-    {
-      $sort: {[sort]: sortOrder}
     }
   )
 
-  const aggregateResult = await mongo.db.collection('users').aggregate(aggregateSteps).toArray()
+  const aggregateResult = await mongo.db.collection('member_activity').aggregate(aggregateSteps).toArray()
+  const indexedUserStats = keyBy(aggregateResult, '_id')
 
-  let currentRanking
-  let currentRankingValue
+  const users = await Member.getAllUsers()
 
-  function computeRanking(value, index) {
-    if (value === currentRankingValue) {
-      return currentRanking
-    }
+  res.send(chain(users)
+    .map(user => {
+      const item = {
+        _id: user._id,
+        firstName: user.profile.firstName,
+        lastName: user.profile.lastName,
+        createdAt: user.createdAt,
+        wpUserId: user.wpUserId,
+        email: user.emails.length > 0 ? user.emails[0].address : null
+      }
 
-    currentRanking = index + 1
-    currentRankingValue = value
-    return currentRanking
-  }
+      const memberStats = indexedUserStats[user._id]
 
-  res.send(aggregateResult.map((r, i) => ({
-    ...pick(r, '_id', 'firstName', 'lastName', 'presencesConso', 'presencesJours', 'createdAt', 'wpUserId'),
-    email: r.emails.length > 0 ? r.emails?.[0].address || '' : '',
-    presences: r.presencesConso,
-    ranking: computeRanking(r[sort], i)
-  })))
+      if (memberStats) {
+        item.presencesConso = memberStats.presencesConso
+        item.presencesJours = memberStats.presencesJours
+      } else {
+        item.presencesConso = 0
+        item.presencesJours = 0
+      }
+
+      return item
+    })
+    .sortBy(member => sortOrder * member[sort])
+    .value()
+  )
 }
 
 export async function getCurrentMembers(req, res) {

--- a/lib/calc.js
+++ b/lib/calc.js
@@ -20,8 +20,8 @@ export function isPresenceDuringAbo(presenceDate, abos) {
   )
 }
 
-export function computeBalance(user) {
-  const {memberships, abos, tickets, presences} = user.profile
+export function computeBalance(user, memberActivity) {
+  const {memberships, tickets} = user.profile
 
   const oldMembershipsCount = memberships
     .filter(m => m.purchaseDate < '2017-02-01')
@@ -29,12 +29,12 @@ export function computeBalance(user) {
 
   const purchasedTickets = sumBy(tickets, 'tickets')
 
-  const usedTickets = chain(presences)
-    .filter(presence => !isPresenceDuringAbo(presence.date, abos))
+  const usedTickets = chain(memberActivity)
+    .filter(activity => activity.type === 'ticket')
     .sumBy('amount')
     .value()
 
-  const firstPresence = minBy(presences, 'date')
+  const firstPresence = minBy(memberActivity, 'date')
   const freeTicket = firstPresence && firstPresence.date < '2017-02-01' ? 1 : 0
 
   return freeTicket + oldMembershipsCount + purchasedTickets - usedTickets

--- a/lib/models/activity.js
+++ b/lib/models/activity.js
@@ -6,13 +6,13 @@ import {isPresenceDuringAbo} from '../calc.js'
 import * as Member from './member.js'
 
 export async function getMemberActivity(memberId) {
-  const member = await Member.getMemberById(memberId)
+  const user = await Member.getUserById(memberId)
 
-  if (!member) {
+  if (!user) {
     throw createHttpError(404, 'Member not found')
   }
 
-  const {abos} = member
+  const {abos} = user.profile
 
   const activity = await mongo.db.collection('member_activity')
     .find({member: memberId})

--- a/lib/models/activity.js
+++ b/lib/models/activity.js
@@ -1,0 +1,52 @@
+import createHttpError from 'http-errors'
+
+import mongo from '../util/mongo.js'
+import {isPresenceDuringAbo} from '../calc.js'
+
+import * as Member from './member.js'
+
+export async function getMemberActivity(memberId) {
+  const member = await Member.getMemberById(memberId)
+
+  if (!member) {
+    throw createHttpError(404, 'Member not found')
+  }
+
+  const {abos} = member
+
+  const activity = await mongo.db.collection('member_activity')
+    .find({member: memberId})
+    .sort({date: -1})
+    .toArray()
+
+  return activity.map(item => ({
+    date: item.date,
+    value: item.value,
+    type: isPresenceDuringAbo(item.date, abos) ? 'subscription' : 'ticket'
+  }))
+}
+
+export async function updateMemberActivity(memberId, date, value) {
+  if (![0, 0.5, 1].includes(value)) {
+    throw createHttpError(400, 'Invalid value')
+  }
+
+  if (!isValidDate(date)) {
+    throw createHttpError(400, 'Invalid date')
+  }
+
+  if (value === 0) {
+    await mongo.db.collection('member_activity').deleteOne({member: memberId, date})
+    return
+  }
+
+  await mongo.db.collection('member_activity').updateOne(
+    {member: memberId, date},
+    {$set: {value}},
+    {upsert: true}
+  )
+}
+
+function isValidDate(date) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) && !Number.isNaN(Date.parse(date))
+}

--- a/lib/models/member.js
+++ b/lib/models/member.js
@@ -1,3 +1,4 @@
+import pMap from 'p-map'
 import {maxBy, sumBy, sortBy, chain, pick} from 'lodash-es'
 import {customAlphabet} from 'nanoid'
 import {sub} from 'date-fns'
@@ -9,6 +10,7 @@ import {convertDateFormat} from '../dates.js'
 import {computeSubcriptionEndDate, computeBalance} from '../calc.js'
 
 import * as Device from './device.js'
+import * as Activity from './activity.js'
 
 const nanoid = customAlphabet('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz')
 
@@ -18,7 +20,7 @@ export async function getAllUsers() {
 
 export async function getAllMembers() {
   const users = await getAllUsers()
-  return users.map(user => computeMemberFromUser(user))
+  return pMap(users, user => computeMemberFromUser(user), {concurrency: 10})
 }
 
 export async function getUserByWordpressId(wordpressId) {
@@ -31,7 +33,7 @@ export async function getUserByEmail(email) {
   })
 }
 
-// This function is a "high performance" way to get an user id from an email as needed by presences. To remove when presences will be able to handle user ids.
+// This function is a "high performance" way to get an user id from an email as needed by probe. To remove when probe will be able to handle user ids.
 export async function getUserIdByEmail(email) {
   const user = await mongo.db.collection('users')
     .findOne({emails: {$elemMatch: {address: email}}}, {projection: {_id: 1}})
@@ -47,7 +49,7 @@ export async function getUserById(id) {
 
 export async function getMemberById(memberId) {
   const user = await getUserById(memberId)
-  const member = computeMemberFromUser(user, {withAbos: true, withActivity: true})
+  const member = await computeMemberFromUser(user, {withAbos: true, withActivity: true})
   member.macAddresses = await Device.getMacAddressesOfMember(memberId)
   return member
 }
@@ -57,17 +59,22 @@ export async function getCurrentMembers(delayInMinutes = 10) {
 
   const users = await mongo.db.collection('users')
     .find({'profile.heartbeat': {$gt: minHeartbeat}})
-    .project({'profile.presences': 0, 'profile.tickets': 0})
+    .project({'profile.tickets': 0})
     .toArray()
 
-  return users.map(user => computeMemberFromUser(user))
+  return pMap(users, user => computeMemberFromUser(user), {concurrency: 10})
 }
 
 export async function getVotingMembers(minActivity = 20) {
   const users = await mongo.db.collection('users').find({}).toArray()
 
-  return chain(users)
-    .map(user => computeMemberFromUser(user, {withActivity: true}))
+  const members = await pMap(
+    users,
+    user => computeMemberFromUser(user, {withActivity: true}),
+    {concurrency: 10}
+  )
+
+  return chain(members)
     .filter(member => member.activity >= minActivity)
     .map(u => pick(u, 'firstName', 'lastName', 'email', 'activity', 'lastMembership', 'balance'))
     .sortBy(u => -u.activity)
@@ -81,7 +88,9 @@ export async function recomputeBalance(memberId) {
     throw new Error(`User not found: ${memberId}`)
   }
 
-  const balance = computeBalance(user)
+  const memberActivity = await Activity.getMemberActivity(memberId)
+
+  const balance = computeBalance(user, memberActivity)
 
   if (balance !== user.profile.balance) {
     await mongo.db.collection('users').updateOne(
@@ -192,7 +201,6 @@ export async function createUser({wpUserId, firstName, lastName, birthDate, emai
     services: {},
     profile: {
       tickets: [],
-      presences: [],
       abos: [],
       memberships: [],
       firstName,
@@ -238,7 +246,7 @@ export function computeMembershipOk(lastMembership) {
   return lastMembership && lastMembership >= currentYear
 }
 
-export function computeMemberFromUser(user, options = {}) {
+export async function computeMemberFromUser(user, options = {}) {
   const {withAbos, withActivity} = options
 
   const today = (new Date()).toISOString().slice(0, 10)
@@ -269,21 +277,22 @@ export function computeMemberFromUser(user, options = {}) {
   member.membershipOk = computeMembershipOk(member.lastMembership)
 
   if (withActivity) {
+    const memberActivity = await Activity.getMemberActivity(user._id)
     const sixMonthsAgo = sub(new Date(), {months: 6}).toISOString().slice(0, 10)
 
-    const sixMonthsActivity = chain(user.profile.presences)
+    const sixMonthsActivity = chain(memberActivity)
       .filter(p => p.date >= sixMonthsAgo)
-      .sumBy('amount')
+      .sumBy('value')
       .value()
 
     member.activity = sixMonthsActivity
     member.activeUser = sixMonthsActivity >= 20
 
-    const totalActivity = sumBy(user.profile.presences, 'amount')
+    const totalActivity = sumBy(memberActivity, 'value')
 
     member.totalActivity = totalActivity
     member.presencesConso = totalActivity
-    member.presencesJours = user.profile.presences.length
+    member.presencesJours = memberActivity.length
     member.trustedUser = totalActivity >= 10
   }
 

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -4,6 +4,7 @@ import mongo from './util/mongo.js'
 import cache from './util/cache.js'
 
 import * as Member from './models/member.js'
+import * as Activity from './models/activity.js'
 
 import {
   getDays,
@@ -19,17 +20,15 @@ import {
 import {isPresenceDuringAbo} from './calc.js'
 
 async function computePresenceStats(range) {
-  const result = await mongo.db.collection('users').aggregate([
-    {$unwind: '$profile.presences'},
-    {$match: {$and: [
-      {'profile.presences.date': {$gte: range[0]}},
-      {'profile.presences.date': {$lte: range[1]}}
-    ]}},
+  const result = await mongo.db.collection('member_activity').aggregate([
+    {$match: {
+      date: {$gte: range[0], $lte: range[1]}
+    }},
     {$group: {
       _id: 1,
-      uniqueUsers: {$addToSet: '$_id'},
+      uniqueUsers: {$addToSet: '$member'},
       presenceDays: {$sum: 1},
-      presenceAmount: {$sum: '$profile.presences.amount'}
+      presenceAmount: {$sum: '$value'}
     }}
   ]).toArray()
 
@@ -49,13 +48,13 @@ async function computePresenceStats(range) {
 }
 
 async function computeNewCoworkersStats(range) {
-  const result = await mongo.db.collection('users').aggregate([
-    {$unwind: '$profile.presences'},
-    {$group: {_id: '$_id', firstCoworkedDay: {$min: '$profile.presences.date'}}},
-    {$match: {$and: [
-      {firstCoworkedDay: {$gte: range[0]}},
-      {firstCoworkedDay: {$lte: range[1]}}
-    ]}},
+  const result = await mongo.db.collection('member_activity').aggregate([
+    {$group: {
+      _id: '$member', firstCoworkedDay: {$min: '$date'}
+    }},
+    {$match: {
+      firstCoworkedDay: {$gte: range[0], $lte: range[1]}
+    }},
     {$group: {_id: 1, count: {$sum: 1}}}
   ]).toArray()
 
@@ -159,26 +158,31 @@ export async function computeStats() {
 }
 
 export async function computeIncomes(periodType, from, to) {
-  const users = await Member.getUsers()
+  const users = await Member.getAllUsers()
 
   const datesIndex = {}
 
-  for (const user of users) {
-    for (const p of user.profile.presences) {
-      const {date, amount} = p
+  await pMap(users, async user => {
+    const memberActivity = await Activity.getMemberActivity(user._id)
+
+    for (const activityEntry of memberActivity) {
+      const {date, value} = activityEntry
 
       if (!datesIndex[date]) {
         datesIndex[date] = []
       }
 
+      if (activityEntry.type === 'subscription') {
+        return
+      }
+
       datesIndex[date].push({
         user,
         date,
-        amount,
-        abo: isPresenceDuringAbo(date, user.profile.abos)
+        amount: value
       })
     }
-  }
+  }, {concurrency: 8})
 
   const periods = getPeriods(periodType, from, to)
 
@@ -188,7 +192,7 @@ export async function computeIncomes(periodType, from, to) {
     const {usedTickets, daysAbo} = days.reduce((dataObj, dayPeriod) => {
       const day = dayPeriod[0]
       const dateEntries = datesIndex[day] || []
-      const tickets = dateEntries.filter(e => !e.abo).reduce(
+      const tickets = dateEntries.reduce(
         (ticketsSum, e) => ticketsSum + e.amount,
         0
       )

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -13,6 +13,10 @@ class Mongo {
     await this.db.collection('devices').createIndex({macAddress: 1}, {unique: true})
     await this.db.collection('devices').createIndex({member: 1})
     await this.db.collection('devices').createIndex({heartbeat: 1})
+
+    await this.db.collection('member_activity').createIndex({member: 1, date: 1}, {unique: true})
+    await this.db.collection('member_activity').createIndex({date: 1})
+    await this.db.collection('member_activity').createIndex({member: 1})
   }
 
   disconnect(force) {

--- a/server.js
+++ b/server.js
@@ -20,7 +20,26 @@ import statsRoutes from './lib/routes/stats.js'
 import * as Member from './lib/models/member.js'
 
 import cache from './lib/util/cache.js'
-import {coworkersNow, getAllMembers, getMemberInfos, getMemberPresences, getMemberTickets, getMemberSubscriptions, heartbeat, getMacAddressesLegacy, updatePresence, purchaseWebhook, forceWordpressSync, getUsersStats, getCurrentMembers, getVotingMembers, updateMemberMacAddresses} from './lib/api.js'
+
+import {
+  coworkersNow,
+  getAllMembers,
+  getMemberInfos,
+  getMemberActivity,
+  getMemberPresences,
+  getMemberTickets,
+  getMemberSubscriptions,
+  heartbeat,
+  getMacAddressesLegacy,
+  updatePresence,
+  purchaseWebhook,
+  forceWordpressSync,
+  getUsersStats,
+  getCurrentMembers,
+  getVotingMembers,
+  updateMemberMacAddresses
+} from './lib/api.js'
+
 import {ensureToken, multiAuth, authRouter} from './lib/auth.js'
 import {ping} from './lib/ping.js'
 import {precomputeStats} from './lib/stats.js'
@@ -88,7 +107,7 @@ app.get('/coworkersNow', w(coworkersNow)) // Legacy
 
 app.get('/api/members', w(multiAuth), w(getAllMembers))
 app.get('/api/members/:userId', w(multiAuth), w(getMemberInfos))
-app.get('/api/members/:userId/presences', w(multiAuth), w(getMemberPresences))
+app.get('/api/members/:userId/activity', w(multiAuth), w(getMemberActivity))
 app.get('/api/members/:userId/tickets', w(multiAuth), w(getMemberTickets))
 app.get('/api/members/:userId/subscriptions', w(multiAuth), w(getMemberSubscriptions))
 app.put('/api/members/:userId/mac-addresses', express.json(), w(multiAuth), w(updateMemberMacAddresses))
@@ -102,6 +121,7 @@ app.get('/api/current-members', w(multiAuth), w(getCurrentMembers))
 
 app.get('/api/user-stats', w(ensureToken), w(resolveUserUsingEmail), w(getMemberInfos))
 app.post('/api/user-stats', express.urlencoded({extended: false}), w(ensureToken), w(resolveUserUsingEmail), w(getMemberInfos))
+app.get('/api/members/:userId/presences', w(multiAuth), w(getMemberPresences))
 app.get('/api/user-presences', w(ensureToken), w(resolveUserUsingEmail), w(getMemberPresences))
 app.get('/api/current-users', w(ensureToken), w(getCurrentMembers))
 


### PR DESCRIPTION
### API changes (no breaking changes)

- Add new route `/api/members/:memberId/activity`
- Deprecate route `/api/members/:memberId/presences`

The only difference is `type` value. `T` is replaced by `ticket`. `A` is replaced by `subscription`.

### Description

Activity data is now stored in a separated collection called `member_activity`. In the future it will allow performance improvements.

During the migration, duplicated activity has been removed.

No review required, it is already deployed in production 😬

