### PR TITLE
Flatten user model (firstName, lastName, email, birthDate)

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -88,7 +88,7 @@ export async function getMacAddressesLegacy(req, res) {
 
   const members = await mongo.db.collection('users')
     .find()
-    .project({'profile.firstName': 1, 'profile.lastName': 1, emails: 1})
+    .project({firstName: 1, lastName: 1, email: 1})
     .toArray()
 
   const rows = []
@@ -100,9 +100,9 @@ export async function getMacAddressesLegacy(req, res) {
       for (const device of memberDevices) {
         rows.push([
           device.macAddress.toUpperCase(),
-          member.emails[0].address,
-          member.profile.firstName,
-          member.profile.lastName
+          member.email,
+          member.firstName,
+          member.lastName
         ])
       }
     }
@@ -243,11 +243,11 @@ export async function getUsersStats(req, res) {
     .map(user => {
       const item = {
         _id: user._id,
-        firstName: user.profile.firstName,
-        lastName: user.profile.lastName,
+        firstName: user.firstName,
+        lastName: user.lastName,
         createdAt: user.createdAt,
         wpUserId: user.wpUserId,
-        email: user.emails.length > 0 ? user.emails[0].address : null
+        email: user.email
       }
 
       const memberStats = indexedUserStats[user._id]

--- a/lib/dates.js
+++ b/lib/dates.js
@@ -21,27 +21,6 @@ export function parseFromTo(from, to) {
   return {from: fromDate, to: toDate}
 }
 
-/**
- * Convertit une date du format YYYYMMDD au format YYYY-MM-DD.
- *
- * @param {string} dateStr - La date à convertir, en format YYYYMMDD.
- * @returns {string} La date au format YYYY-MM-DD.
- * @throws {Error} Lance une erreur si le format de la date d'entrée n'est pas valide.
- */
-export function convertDateFormat(dateStr) {
-  dateStr = String(dateStr)
-
-  if (dateStr.length !== 8) {
-    return
-  }
-
-  const year = dateStr.slice(0, 4)
-  const month = dateStr.slice(4, 6)
-  const day = dateStr.slice(6, 8)
-
-  return `${year}-${month}-${day}`
-}
-
 export function formatDate(date) {
   return formatISO(date, {representation: 'date'})
 }

--- a/lib/models/member.js
+++ b/lib/models/member.js
@@ -6,7 +6,6 @@ import {sub} from 'date-fns'
 import mongo from '../util/mongo.js'
 import {getUser as getWpUser} from '../util/wordpress.js'
 
-import {convertDateFormat} from '../dates.js'
 import {computeSubcriptionEndDate, computeBalance} from '../calc.js'
 
 import * as Device from './device.js'
@@ -28,15 +27,13 @@ export async function getUserByWordpressId(wordpressId) {
 }
 
 export async function getUserByEmail(email) {
-  return mongo.db.collection('users').findOne({
-    emails: {$elemMatch: {address: email}}
-  })
+  return mongo.db.collection('users').findOne({email})
 }
 
 // This function is a "high performance" way to get an user id from an email as needed by probe. To remove when probe will be able to handle user ids.
 export async function getUserIdByEmail(email) {
   const user = await mongo.db.collection('users')
-    .findOne({emails: {$elemMatch: {address: email}}}, {projection: {_id: 1}})
+    .findOne({email}, {projection: {_id: 1}})
 
   if (user) {
     return user._id
@@ -119,18 +116,16 @@ export async function syncWithWordpress(memberId) {
     throw new Error(`Unable to sync ${memberId}: WP user ${user.wpUserId} not found`)
   }
 
-  const {email, first_name: firstName, last_name: lastName} = wpUser
-
-  const {date_naissance} = wpUser.acf
+  const {email, first_name: firstName, last_name: lastName, acf: {date_naissance: birthDate}} = wpUser
 
   await mongo.db.collection('users').updateOne(
     {_id: memberId},
     {
       $set: {
-        emails: [{address: email, verified: false}],
-        'profile.firstName': firstName,
-        'profile.lastName': lastName,
-        'profile.birthDate': convertDateFormat(date_naissance)
+        email,
+        firstName,
+        lastName,
+        birthDate
       }
     }
   )
@@ -160,10 +155,8 @@ export async function reconcileWithWordpressId(wpUserId) {
     email,
     first_name: firstName,
     last_name: lastName,
-    acf
+    acf: {date_naissance: birthDate}
   } = await getWpUser(wpUserId)
-
-  const birthDate = convertDateFormat(acf.date_naissance)
 
   // Try to find the user with its wordpress email
   user = await getUserByEmail(email)
@@ -175,10 +168,10 @@ export async function reconcileWithWordpressId(wpUserId) {
       {
         $set: {
           wpUserId,
-          emails: [{address: email, verified: false}],
-          'profile.firstName': firstName,
-          'profile.lastName': lastName,
-          'profile.birthDate': birthDate
+          email,
+          firstName,
+          lastName,
+          birthDate
         }
       }
     )
@@ -195,17 +188,14 @@ export async function createUser({wpUserId, firstName, lastName, birthDate, emai
     _id: nanoid(17),
     wpUserId,
     createdAt: new Date(),
-    emails: [
-      {address: email, verified: false}
-    ],
-    services: {},
+    firstName,
+    lastName,
+    email,
+    birthDate,
     profile: {
       tickets: [],
       abos: [],
       memberships: [],
-      firstName,
-      lastName,
-      birthDate,
       isAdmin: false,
       balance: 0,
       heartbeat: null
@@ -255,10 +245,10 @@ export async function computeMemberFromUser(user, options = {}) {
     _id: user._id,
     created: user.createdAt,
     wpUserId: user.wpUserId,
-    firstName: user.profile.firstName,
-    lastName: user.profile.lastName,
-    birthDate: user.profile.birthDate,
-    email: user.emails[0].address,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    birthDate: user.birthDate,
+    email: user.email,
     balance: user.profile.balance,
     lastSeen: user.profile.heartbeat
   }

--- a/scripts/send-notification-emails.js
+++ b/scripts/send-notification-emails.js
@@ -15,7 +15,7 @@ await mongo.connect()
 const expiringAboStartDate = add(sub(new Date(), {months: 1}), {days: 1}).toISOString().slice(0, 10)
 const candidateEndOfAboUsers = await mongo.db.collection('users')
   .find({'profile.abos': {$elemMatch: {aboStart: expiringAboStartDate}}})
-  .project({_id: 0, 'emails.address': 1, 'profile.abos': 1})
+  .project({_id: 0, email: 1, 'profile.abos': 1})
   .toArray()
 const tomorrow = add(new Date(), {days: 1}).toISOString().slice(0, 10)
 const oneMonthBeforeTomorrow = sub(new Date(tomorrow), {months: 1}).toISOString().slice(0, 10)
@@ -25,7 +25,7 @@ const endOfAboUsers = candidateEndOfAboUsers.filter(user => {
   )
   return !hasAboForTomorrow
 })
-const endOfAboEmails = chain(endOfAboUsers).map('emails').flatten().value()
+const endOfAboEmails = chain(endOfAboUsers).map('email').value()
 await Promise.all(endOfAboEmails.map(async email => sendMail(
   renderFinAbonnement(),
   [email]
@@ -35,7 +35,7 @@ await Promise.all(endOfAboEmails.map(async email => sendMail(
 const yesterday = sub(new Date(), {days: 1}).toISOString().slice(0, 10)
 const todayUsers = await mongo.db.collection('users')
   .find({'profile.heartbeat': {$gt: yesterday}})
-  .project({_id: 0, 'emails.address': 1, profile: 1})
+  .project({_id: 0, email: 1, profile: 1})
   .toArray()
 const today = (new Date()).toISOString().slice(0, 10)
 const oneMonthAgo = sub(new Date(), {months: 1}).toISOString().slice(0, 10)
@@ -43,7 +43,7 @@ const outOfTicketsUsers = todayUsers.filter(user => {
   const isDuringAbo = user.profile.abos.some(abo => oneMonthAgo < abo.aboStart && abo.aboStart <= today)
   return !isDuringAbo && user.profile.balance <= 0
 })
-const outOfTicketsEmails = chain(outOfTicketsUsers).map('emails').flatten().value()
+const outOfTicketsEmails = chain(outOfTicketsUsers).map('email').value()
 await Promise.all(outOfTicketsEmails.map(async email => sendMail(
   renderPlusDeTickets(),
   [email]


### PR DESCRIPTION
Move `firstName`, `lastName` and `birthDate` to main user/member object.
Fix `birthDate` conversion step.
Only keep one email address and store it in `email`.

No changes on Web API.