### PR TITLE
feat(auth): add wordpress user id in access token

### DIFF
--- a/lib/util/jwt.js
+++ b/lib/util/jwt.js
@@ -20,7 +20,8 @@ if (!JWT_REFRESH_TOKEN_SECRET_KEY || JWT_REFRESH_TOKEN_SECRET_KEY.length < 32) {
 
 export function createAccessToken(user, wordpressUser) {
   const payload = {
-    id: user?._id ?? wordpressUser.id,
+    id: user?._id ?? null,
+    wpUserId: wordpressUser.id,
     email: user?.email ?? wordpressUser.user_email,
     name: [user?.firstName, user?.lastName].filter(Boolean).join(' ') || wordpressUser.display_name,
     roles: wordpressUser.roles,


### PR DESCRIPTION
Pour être capable d'un point de vue front-end si des appels à `/members/:id/*` peuvent être exécutés