### PR TITLE
Sync user

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -141,7 +141,12 @@ export async function syncUserWebhook(req, res) {
 
   const user = await mongo.db.collection('users').findOne({wpUserId}, {projection: {_id: 1}})
 
-  Member.reconcileWithWordpressId(user._id)
+  if (!user?._id) {
+    return res.sendStatus(403)
+  }
+  
+  await Member.syncWithWordpress(user._id)
+
   res.sendStatus(200)
 }
 /* Services */

--- a/lib/api.js
+++ b/lib/api.js
@@ -133,6 +133,19 @@ export async function updatePresence(req, res) {
   res.sendStatus(200)
 }
 
+export async function syncUserWebhook(req, res) {
+  const wpUserId = Number(req.body?.wpUserId || req.query?.wpUserId)
+  if (!wpUserId) {
+    return res.sendStatus(403)
+  }
+
+  const user = await mongo.db.collection('users').findOne({wpUserId}, {projection: {_id: 1}})
+
+  Member.reconcileWithWordpressId(user._id)
+  res.sendStatus(200)
+}
+/* Services */
+
 export async function purchaseWebhook(req, res) {
   if (req.body.status !== 'completed') {
     return res.sendStatus(200)

--- a/server.js
+++ b/server.js
@@ -33,6 +33,7 @@ import {
   getMacAddressesLegacy,
   updatePresence,
   purchaseWebhook,
+  syncUserWebhook,
   forceWordpressSync,
   getUsersStats,
   getCurrentMembers,
@@ -134,6 +135,7 @@ app.post('/api/presence', express.urlencoded({extended: false}), w(ensureToken),
 /* Webhooks */
 
 app.post('/api/purchase-webhook', validateAndParseJson, w(purchaseWebhook))
+app.post('/api/sync-user-webhook', validateAndParseJson, w(syncUserWebhook))
 
 /* Services */
 


### PR DESCRIPTION
 The syncUserWebhook was not actually making the call to sync the user with wordpress. 
It was calling reconcileWithWordpressId who does not do the sync (and reconcileWithWordpressId was called with the local user id, when it should receive a wpuserId).

The call to  syncWithWordpress was added in syncUserWebhook instead of reconcileWithWordpressId.