### PR TITLE
Ensure localhost URLs bypass the OAuth follow whitelist

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -106,6 +106,11 @@ function isFollowAllowed(followUrl) {
     return false
   }
 
+  const url = new URL(followUrl)
+  if (url.hostname === 'localhost') {
+    return true
+  }
+
   const whitelist = OAUTH_FOLLOW_WHITELIST.split(',')
   return whitelist.includes(followUrl)
 }


### PR DESCRIPTION
This commit updates the `isFollowAllowed` function to immediately return true for any URL that originates from `localhost`. This allows for easier development and testing locally without needing to modify the OAuth follow whitelist. If the URL is not from localhost, the function then proceeds to check against the existing whitelist as before.