### PR TITLE
feat(on-premise): require trusted user to unlock deck door

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -207,7 +207,7 @@ export function buildOauth2Callback(path) {
         const wordpressUser = await getWordpressUser(oauthAccessToken)
         const user = await getUserByWordpressId(wordpressUser.id)
 
-        const jwtAccessToken = createAccessToken(user, wordpressUser)
+        const jwtAccessToken = await createAccessToken(user, wordpressUser)
         redirectUrl.searchParams.append('accessToken', jwtAccessToken)
         const jwtRefreshToken = createRefreshToken(oauthRefreshToken)
         redirectUrl.searchParams.append('refreshToken', jwtRefreshToken)
@@ -258,7 +258,7 @@ export async function refreshTokens(jwtRefreshToken) {
   const wordpressUser = await getWordpressUser(newOauthAccessToken)
   const user = await getUserByWordpressId(wordpressUser.id)
 
-  const newAccessToken = createAccessToken(user, wordpressUser)
+  const newAccessToken = await createAccessToken(user, wordpressUser)
   const newRefreshToken = createRefreshToken(newOauthRefreshToken)
 
   return {

--- a/lib/routes/on-premise.js
+++ b/lib/routes/on-premise.js
@@ -4,6 +4,7 @@ import w from '../util/w.js'
 
 import {getCurrentState, getPhoneBoothsOccupation, unlockDeckDoor} from '../services/home-assistant.js'
 import {add} from 'date-fns'
+import createHttpError from 'http-errors'
 
 async function createRoutes() {
   const router = new Router()
@@ -17,6 +18,10 @@ async function createRoutes() {
   }))
 
   router.post('/deck-door/unlock', w(async (req, res) => {
+    if (!req.user.capabilities.includes('UNLOCK_DECK_DOOR')) {
+      throw createHttpError(403, 'Vous n\'avez pas l\'autorisation de déverrouiller la porte')
+    }
+
     // At least log who is unlocking the door
     console.log(`${req.user?.email || 'Someone'} is unlocking deck door`)
 

--- a/lib/util/jwt.js
+++ b/lib/util/jwt.js
@@ -3,6 +3,7 @@ import {Buffer} from 'node:buffer'
 import process from 'node:process'
 import jwt from 'jsonwebtoken'
 import {buildPictureUrl} from './wordpress.js'
+import {computeMemberFromUser} from '../models/member.js'
 
 const {
   JWT_ACCESS_TOKEN_PRIVATE_KEY,
@@ -18,7 +19,9 @@ if (!JWT_REFRESH_TOKEN_SECRET_KEY || JWT_REFRESH_TOKEN_SECRET_KEY.length < 32) {
   throw new Error('JWT_REFRESH_TOKEN_SECRET_KEY must be defined with at least 32 characters')
 }
 
-export function createAccessToken(user, wordpressUser) {
+export async function createAccessToken(user, wordpressUser) {
+  const member = await computeMemberFromUser(user, {withAbos: true, withActivity: true})
+
   const payload = {
     id: user?._id ?? null,
     wpUserId: wordpressUser.id,
@@ -45,9 +48,10 @@ export function createAccessToken(user, wordpressUser) {
   }
 
   if (wordpressUser.roles.includes('coworker') || isUserOnboardingToday) {
-    payload.capabilities.push([
+    payload.capabilities.push(...[
       wordpressUser.droits.ouvrir_portail && 'UNLOCK_GATE',
-      wordpressUser.droits.ouvrir_parking && 'PARKING_ACCESS'
+      wordpressUser.droits.ouvrir_parking && 'PARKING_ACCESS',
+      member.trustedUser && 'UNLOCK_DECK_DOOR'
     ].filter(Boolean))
   }
 


### PR DESCRIPTION
To avoid freshly new members accessing the open space on their own, unlocking the deck door now requires to be `trusted`. Meaning member should have at least 10 days of presence before accessing this feature.