### PR TITLE
feat(on-premise): add `/key-box/code` endpoint

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,3 +35,5 @@ JWT_REFRESH_TOKEN_SECRET_KEY= # at least 32 characters
 
 AMOUR_FOOD_API_BASE_URL=https://lamourfood.fr/wp-json/
 CALENDAR_EVENTS_URL=
+
+KEY_BOX_CODE=

--- a/lib/routes/on-premise.js
+++ b/lib/routes/on-premise.js
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import {Router} from 'express'
 
 import w from '../util/w.js'
@@ -30,7 +31,24 @@ async function createRoutes() {
     res.send({
       triggered: now.toISOString(),
       locked: add(now, {seconds: 60}).toISOString(),
-      timeout: 'PT60S' // Didn't count yet but I suspect a 60 seconds period
+      timeout: 'PT60S'
+    })
+  }))
+
+  router.get('/key-box/code', w(async (req, res) => {
+    if (!process.env.KEY_BOX_CODE) {
+      throw createHttpError(501, 'Le code de la boîte à clé n\'est pas configuré')
+    }
+
+    if (!req.user.capabilities.includes('KEYS_ACCESS')) {
+      throw createHttpError(403, 'Vous n\'avez pas l\'autorisation d\'ouvrir la boîte à clé')
+    }
+
+    // At least log who is opening key box
+    console.log(`${req.user?.email || 'Someone'} is retrieving key box code`)
+
+    res.send({
+      code: process.env.KEY_BOX_CODE
     })
   }))
 

--- a/lib/util/jwt.js
+++ b/lib/util/jwt.js
@@ -53,7 +53,7 @@ export async function createAccessToken(user, wordpressUser) {
   if (user) {
     const member = await computeMemberFromUser(user, {withAbos: true, withActivity: true})
     if (member.trustedUser) {
-      payload.capabilities.push('UNLOCK_DECK_DOOR')
+      payload.capabilities.push('UNLOCK_DECK_DOOR', 'KEYS_ACCESS')
     }
   }
 


### PR DESCRIPTION
Permet de récupérer le code de la boîte à clés si l'utilisateur est un `trustedUser`, c'est-à-dire qu'il a réalisé au moins 10 jours de présence.