### PR TITLE
refactor(wordpress): prefer `.json()` over `responseType: json`

### DIFF
--- a/lib/util/wordpress.js
+++ b/lib/util/wordpress.js
@@ -19,13 +19,12 @@ export async function getOrders(year) {
 }
 
 export async function getUser(userId) {
-  const response = await got(`${WORDPRESS_BASE_URL}/api-json-wp/wp/v2/users/${userId}?context=edit`, {
-    responseType: 'json', // Prefer over `.json()` to parse JSON response
+  const user = await got(`${WORDPRESS_BASE_URL}/api-json-wp/wp/v2/users/${userId}?context=edit`, {
     username: process.env.WP_APIV2_USERNAME,
     password: process.env.WP_APIV2_PASSWORD
-  })
+  }).json()
 
-  return response.body
+  return user
 }
 
 export function getUserFromOAuthAccessToken(accessToken) {


### PR DESCRIPTION
Il suffisait d'enlever le `.body` dans `response` pour que ça fonctionne avec `.json()` puisque ce dernier fait 2 choses :
- il demande une réponse `json` en header,
- il parse le contenu comme `json` et le renvoie directement (plutôt que renvoyer la réponse)  🙂