### PR TITLE
Abos successifs

### DIFF
--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -21,7 +21,7 @@ export async function getMemberSubscriptions(memberId) {
   const subscriptions = await mongo.db.collection('subscriptions').find({memberId}).toArray()
   return chain(subscriptions)
     .map(s => formatSubscription(s))
-    .orderBy(['purchased'], ['desc'])
+    .orderBy(['purchased', 'started'], ['desc', 'desc'])
     .value()
 }
 

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -35,6 +35,7 @@ export async function addSubscriptionsToMember(memberId, startDate, purchase, pu
   const payloads = []
   for (let i = 0; i < purchaseQuantity; i++) {
     payload._id = nanoid(17)
+    payload.startDate = add(new Date(payload.startDate), {months: i}).toISOString().slice(0, 10)
     payloads.push({...payload})
   }
 


### PR DESCRIPTION
J'ai repris le morceau de code des abos legacy dans la nouvelle collection abos. Si on achète n abos, chaque abos après le premier verra sa date de début décalée d'un moi.
J'ai aussi modifié le tri des achats dans la route user / subscriptions