### PR TITLE
Presence webhook

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -2,6 +2,7 @@ import {isValid, sub} from 'date-fns'
 import {keyBy, groupBy, chain, xor, isEqual} from 'lodash-es'
 
 import mongo from './util/mongo.js'
+import {createFlag, getFlagResponse} from './util/flags.js'
 
 import * as Member from './models/member.js'
 import * as Ticket from './models/ticket.js'
@@ -235,6 +236,37 @@ export async function syncUserWebhook(req, res) {
   await Member.syncWithWordpress(user._id)
 
   res.sendStatus(200)
+}
+
+export async function getFlag(req, res) {
+  const {flagId} = req.params
+
+  const response = await getFlagResponse(flagId)
+  res.send(response)
+}
+
+export async function presenceWebhook(req, res) {
+  const {action} = req.body
+
+  // We want to trigger the reupload of presences for the fiven MAC Address
+  if (action === 'mac') {
+    const {mac} = req.body
+    const flagId = await createFlag('presences-mac', {mac})
+    res.send({flagId})
+  }
+
+  // We want to trigger the reupload of presences for the given time period
+  if (action === 'period') {
+    const {period} = req.body
+    const flagId = await createFlag('presences-period', {period})
+    res.send({flagId})
+  }
+
+  // We want to trigger the (re)upload of presences of the current day
+  if (action === 'day') {
+    const flagId = await createFlag('presences-day')
+    res.send({flagId})
+  }
 }
 
 export async function purchaseWebhook(req, res) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -248,10 +248,14 @@ export async function getFlag(req, res) {
 export async function presenceWebhook(req, res) {
   const {action} = req.body
 
-  // We want to trigger the reupload of presences for the fiven MAC Address
+  // We want to trigger the reupload of presences for the given MAC Address
   if (action === 'mac') {
-    const {mac} = req.body
-    const flagId = await createFlag('presences-mac', {mac})
+    let {mac, period} = req.body
+
+    // Si period est null ou non défini, définir period à l'année en cours
+    period = period ?? new Date().getFullYear()
+
+    const flagId = await createFlag('presences-mac', {mac, period})
     res.send({flagId})
   }
 

--- a/lib/util/flags.js
+++ b/lib/util/flags.js
@@ -1,0 +1,94 @@
+import {promises as fs} from 'node:fs'
+import {join as joinPath} from 'node:path'
+import {tmpdir} from 'node:os'
+import {genUUID} from './uuid.js'
+
+export async function purgeOldFlags() {
+  const dirPath = joinPath(tmpdir(), 'flags')
+
+  try {
+    const files = await fs.readdir(dirPath)
+    const now = Date.now()
+    const deletionPromises = []
+
+    for (const file of files) {
+      const filePath = joinPath(dirPath, file)
+
+      deletionPromises.push(
+        fs.stat(filePath).then(stats => {
+          // If the file was modified more than 24 hours ago, delete it
+          if (now - stats.mtimeMs > 24 * 60 * 60 * 1000) {
+            return fs.unlink(filePath)
+          }
+        })
+      )
+    }
+
+    await Promise.all(deletionPromises)
+  } catch (error) {
+    console.error('Error while purging old flag files:', error)
+  }
+}
+
+/**
+ * Reads and outputs the content of the specified flag file and its corresponding '.response' file.
+ * After reading, it deletes both files.
+ *
+ * @param {String} flagId - The identifier of the flag file to read.
+ * @returns {Promise<Object>} A promise that resolves with an object containing the contents of the flag file and its response file.
+ */
+export async function getFlagResponse(flagId) {
+  const dirPath = joinPath(tmpdir(), 'flags')
+  const filePath = joinPath(dirPath, flagId)
+  const responseFilePath = `${filePath}.response`
+  const streamFilePath = `${filePath}.stream`
+
+  const payload = {options: null, response: null}
+  try {
+    // Read the contents of the flag file
+    payload.options = JSON.parse(await fs.readFile(filePath, 'utf8'))
+
+    try {
+      // Try to read the contents of the response file (if it exists)
+      payload.response = await fs.readFile(responseFilePath, 'utf8')
+      // Delete flag file and its response file after reading them
+      await Promise.all([fs.unlink(filePath), fs.unlink(responseFilePath)])
+    } catch {
+      try {
+        payload.response = await fs.readFile(streamFilePath, 'utf8')
+      } catch {}
+    }
+
+    console.log(payload)
+
+    return payload
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+/**
+ * Creates a flag file in /tmp/flags with the given slug and JSON options.
+ * @param {String} flagSlug - The slug identifiying the flag.
+ * @param {Object} options - The options to JSON stringify and write to the file.
+ */
+export async function createFlag(flagSlug, options = {}) {
+  purgeOldFlags()
+  const flagId = `${flagSlug}-${genUUID()}`
+  options.id = flagId
+  options.slug = flagSlug
+  const dirPath = joinPath(tmpdir(), 'flags')
+  const filePath = joinPath(dirPath, flagId)
+
+  try {
+    // Create the directory if it does not exist
+    await fs.mkdir(dirPath, {recursive: true})
+    // Write the JSON options to the flag file
+    await fs.writeFile(filePath, JSON.stringify(options, null, 2))
+    console.log(`Flag file created successfully at ${filePath}`)
+    return flagId
+  } catch (error) {
+    console.error('Error while creating flag file:', error)
+  }
+}
+

--- a/lib/util/uuid.js
+++ b/lib/util/uuid.js
@@ -1,0 +1,24 @@
+/**
+ * Generates a universally unique identifier (UUID) following version 4 standards.
+ * The UUID is a 36 character length string (including 4 hyphens),
+ * with hexadecimal characters in the format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx,
+ * where x is any hexadecimal digit and y is one of 8, 9, A, or B.
+ * @returns {string} - The generated UUID.
+ *
+ * @example
+ * const id = genUUID();
+ * console.log(id); // Outputs something like: '3b2412c1-37f9-4ff5-8abc-726595f448ea'
+ */
+export function genUUID() {
+  // Function to generate a random integer between 0 and 15
+  const randomHex = () => Math.floor(Math.random() * 16).toString(16)
+
+  // Generate UUID segments
+  const s4 = () => randomHex() + randomHex() + randomHex() + randomHex()
+  const s3 = () => randomHex() + randomHex() + randomHex()
+
+  // Construct the UUID using specific format
+  return `${s4()}${s4()}-4${s3()}-y${s3()}-${
+    (8 + Math.floor(Math.random() * 4)).toString(16) // Variant code 8, 9, A, or B
+  }${s3()}-${s4()}${s4()}`
+}

--- a/server.js
+++ b/server.js
@@ -33,7 +33,9 @@ import {
   heartbeat,
   getMacAddressesLegacy,
   updatePresence,
+  getFlag,
   purchaseWebhook,
+  presenceWebhook,
   syncUserWebhook,
   forceWordpressSync,
   getUsersStats,
@@ -126,6 +128,8 @@ app.post('/api/presence', express.urlencoded({extended: false}), w(ensureToken),
 
 /* Webhooks */
 
+app.get('/api/flags/:flagId', express.urlencoded({extended: false}), w(ensureToken), w(getFlag))
+app.post('/api/presence-webhook', express.json(), w(ensureToken), w(presenceWebhook))
 app.post('/api/purchase-webhook', validateAndParseJson, w(purchaseWebhook))
 app.post('/api/sync-user-webhook', validateAndParseJson, w(syncUserWebhook))
 


### PR DESCRIPTION
Ajout de deux routes api : 
# Routes
## presence-webhook
Permet d'interroger un webhook destiné à déclencher le traitement des présences, avec des paramètres spécifiques :

* déclencher le ré-upload des présences pour l'adresse MAC donnée
* déclencher le ré-upload des présences pour une période de temps donnée (Au choix : "2024" pour toute une année, "2024-10" pour un mois donné ou "2024-10-01" pour un jour donné)
* déclencher le ré-upload (ou upload) des présences du jour courant

Le webhook est asynchrone et va simplement ajouter un flag qui dira à `traitement-presences`de lancer le script voulu.
Chaque appel à ce webhook retourne un identifiant de traitement, qui sera utilisé ensuite si on veut avoir des infos sur la vie du traitement après son lancement

## flags
Les flags, composés de fichiers temporaires déposés par tickets-backend dans le filesystem du serveur, servent à transmettre des informations à d'autres traitements. Une application de ces flags est de déspoer un fichier flag pour déclencher le script [flags.sh](https://github.com/coworking-metz/traitement-presences/blob/master/flags.sh) dans [traitement-presences](https://github.com/coworking-metz/traitement-presences/). La route API ajoutée permet de de suivre l'état d'un flag. Les états d'un flag peuvent être : 
 * en attente: fichier flag déposé, non commencé et non traité.
 * en cours de traitement: flag détecté, et traitement en cours (un fichier stream est mis à jour en temps réel avec la stdout du script qui a été lancé via le flag).
 * terminé: traitement terminé, flag supprimé. Un fichier response est créé contenant l'intégralité de la stdout du script.
 
# Objectif
**Cela permettra d'ajouter un bouton pour réuploader des présences depuis manager et/ou wordpress.**. 

# A suivre
Il faut encore dev la partie qui va lire les fichiers de flags et lancer les scripts shell demandés, au sein du dépot traitement-presences via un service unix