### PR TITLE
fix(subscriptions): do not override first subscription when adding multiple

### DIFF
--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -26,26 +26,23 @@ export async function getMemberSubscriptions(memberId) {
 }
 
 export async function addSubscriptionsToMember(memberId, startDate, purchase, purchaseQuantity = 1) {
-  const payload = {
-    _id: null,
-    memberId,
-    startDate,
-    ...purchase
-  }
-  const payloads = []
+  const allNewSubscriptions = []
   for (let i = 0; i < purchaseQuantity; i++) {
-    payload._id = nanoid(17)
-    payload.startDate = add(new Date(payload.startDate), {months: i}).toISOString().slice(0, 10)
-    payloads.push({...payload})
+    allNewSubscriptions.push({
+      ...purchase,
+      _id: nanoid(17),
+      startDate: add(new Date(startDate), {months: i}).toISOString().slice(0, 10),
+      memberId
+    })
   }
 
   if (!purchase.migratedFromUsersCollection) {
     await addSubscriptionsToMemberLegacy(memberId, purchase.purchaseDate, startDate, purchaseQuantity) // For data consistency
   }
 
-  return Promise.all(payloads.map(async p => {
-    await mongo.db.collection('subscriptions').insertOne(p)
-    return p
+  return Promise.all(allNewSubscriptions.map(async s => {
+    await mongo.db.collection('subscriptions').insertOne(s)
+    return s
   }))
 }
 


### PR DESCRIPTION
Corrige un soucis de désynchronisation entre les collections `users.profile.abos` et `subscriptions` où les dates ne sont pas les mêmes
<img width="1166" height="895" alt="image" src="https://github.com/user-attachments/assets/e2516d72-87bf-4fe1-a41b-0e157d2441fb" />
