### PR TITLE
feat(auth): partially refresh tokens when wordpress is unavailable

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -264,20 +264,43 @@ export async function retrieveUserFromAccessToken(req) {
  * by requesting new ones from the OAuth server
  * and validating the user
  */
-export async function refreshTokens(jwtRefreshToken) {
+export async function refreshTokens(jwtRefreshToken, jwtAccessToken) {
   const oauthRefreshToken = await verifyRefreshToken(jwtRefreshToken)
-  const {access_token: newOauthAccessToken, refresh_token: newOauthRefreshToken} = await refreshOAuthTokens(oauthRefreshToken)
 
-  const wordpressUser = await getWordpressUser(newOauthAccessToken)
-  const user = await getUserByWordpressId(wordpressUser.id)
+  return refreshOAuthTokens(oauthRefreshToken).then(async ({
+    access_token: newOauthAccessToken,
+    refresh_token: newOauthRefreshToken
+  }) => {
+    const wordpressUser = await getWordpressUser(newOauthAccessToken)
+    const user = await getUserByWordpressId(wordpressUser.id)
 
-  const newAccessToken = await createAccessToken(user, wordpressUser)
-  const newRefreshToken = createRefreshToken(newOauthRefreshToken)
+    const newAccessToken = await createAccessToken(user, wordpressUser)
+    const newRefreshToken = createRefreshToken(newOauthRefreshToken)
 
-  return {
-    accessToken: newAccessToken,
-    refreshToken: newRefreshToken
-  }
+    return {
+      accessToken: newAccessToken,
+      refreshToken: newRefreshToken
+    }
+  }).catch(async error => {
+    // Handle WordPress 500 errors gracefully
+    // by returning new access token with existing refresh token
+    if (error.code === 'ERR_NON_2XX_3XX_RESPONSE' && error.response.statusCode === 500) {
+      const userFromAccessToken = jwt.decode(jwtAccessToken)
+      if (userFromAccessToken) {
+        const user = await getUserByWordpressId(userFromAccessToken.wpUserId)
+        const wordpressUser = {id: userFromAccessToken.wpUserId, roles: userFromAccessToken.roles}
+
+        const newAccessToken = await createAccessToken(user, wordpressUser)
+
+        return {
+          accessToken: newAccessToken,
+          refreshToken: jwtRefreshToken
+        }
+      }
+    }
+
+    throw error
+  })
 }
 
 // Make it a little bit more fun
@@ -302,7 +325,8 @@ export function authRouter() {
   router.get('/callback', w(buildOauth2Callback('/callback')))
   router.post('/tokens', express.json(), w(async (req, res) => {
     const jwtRefreshToken = req.body.refreshToken
-    const {accessToken, refreshToken, user} = await refreshTokens(jwtRefreshToken)
+    const jwtAccessToken = req.body.accessToken
+    const {accessToken, refreshToken, user} = await refreshTokens(jwtRefreshToken, jwtAccessToken)
       .catch(error => {
         if (error instanceof jwt.TokenExpiredError
           || error instanceof jwt.JsonWebTokenError

--- a/lib/util/wordpress.js
+++ b/lib/util/wordpress.js
@@ -31,6 +31,9 @@ export function getUserFromOAuthAccessToken(accessToken) {
   return got.post(`${WORDPRESS_BASE_URL}/oauth/me`, {
     headers: {
       Authorization: `Bearer ${accessToken}`
+    },
+    timeout: {
+      request: 20_000 // 20 seconds
     }
   }).json()
 }
@@ -42,6 +45,9 @@ export function refreshOAuthTokens(refreshToken) {
       refresh_token: refreshToken,
       client_id: WORDPRESS_OAUTH_CLIENT_ID,
       client_secret: WORDPRESS_OAUTH_CLIENT_SECRET
+    },
+    timeout: {
+      request: 20_000 // 20 seconds
     }
   }).json()
 }

--- a/mock/mockoon.json
+++ b/mock/mockoon.json
@@ -51,6 +51,16 @@
       "uuid": "995a1310-9db4-4712-ad26-d1ca0662b4a9",
       "name": "Gemini",
       "children": []
+    },
+    {
+      "uuid": "4ad5c5da-e770-4690-bfca-2371ea1dd4cd",
+      "name": "Wordpress",
+      "children": [
+        {
+          "type": "route",
+          "uuid": "37e0ee28-689d-4e8f-a652-56dd63d52f08"
+        }
+      ]
     }
   ],
   "routes": [
@@ -294,6 +304,37 @@
       "responseMode": null,
       "streamingMode": null,
       "streamingInterval": 0
+    },
+    {
+      "uuid": "37e0ee28-689d-4e8f-a652-56dd63d52f08",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "wordpress/oauth/token",
+      "responses": [
+        {
+          "uuid": "35d51a32-dccd-4f50-94ef-80df0d399b3a",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 500,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
     }
   ],
   "rootChildren": [
@@ -308,6 +349,10 @@
     {
       "type": "folder",
       "uuid": "995a1310-9db4-4712-ad26-d1ca0662b4a9"
+    },
+    {
+      "type": "folder",
+      "uuid": "4ad5c5da-e770-4690-bfca-2371ea1dd4cd"
     }
   ],
   "proxyMode": false,


### PR DESCRIPTION
WordPress étant parfois instable et inaccessible, on peut se permettre de rafraîchir l'access token des utilisateurs sans rafraîchir le refresh token lorsque c'est demandé.
L'objectif est de maintenir les services essentiels accessibles (entrer et sortir du coworking) même si le coworking-metz.fr est en erreur.
Si le site ne répond plus cependant, alors on continue à retourner une erreur.

Ça ne fonctionnera que pour les utilisateurs qui sont déjà connectés et qui ont en mémoire leur access tokens ET refresh tokens.
Ça demandera une évolution de https://github.com/coworking-metz/mobile-app, et je n'ai pas encore réfléchi à ce que je vais faire pour https://github.com/coworking-metz/tickets-manager-web.