### PR TITLE
Pouvoir editer des valeurs d'attributs qui sont stockés principalement dans Wordpress

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 import {isAfter, isValid, isWithinInterval, parseISO, sub} from 'date-fns'
 import {chain, groupBy, isEqual, isNil, keyBy, xor} from 'lodash-es'
 
+import cache from './util/cache.js'
 import {createFlag, getFlagResponse} from './util/flags.js'
 import mongo from './util/mongo.js'
 
@@ -578,16 +579,24 @@ export async function getMemberDevices(req, res) {
  * They are defined in WordPress and cached here, so that clients can build their
  * dropdowns without knowing where the list comes from, and without paying a
  * WordPress round-trip on every request.
+ *
+ * The shared cache is used rather than a module variable: it survives a restart,
+ * and it can be emptied from the manager if the list has to be picked up again
+ * before the end of the TTL.
  */
+const MEMBER_ATTRIBUTES_CACHE_KEY = 'MEMBER_ATTRIBUTES'
 const MEMBER_ATTRIBUTES_TTL_IN_MS = 24 * 60 * 60 * 1000
-let memberAttributes = null
 
 export async function getMemberAttributes(req, res) {
+  let memberAttributes = await cache.get(MEMBER_ATTRIBUTES_CACHE_KEY)
+
   if (!memberAttributes || Date.now() - memberAttributes.fetchedAt > MEMBER_ATTRIBUTES_TTL_IN_MS) {
     memberAttributes = {
       fetchedAt: Date.now(),
       choices: await Wordpress.getUserOptionsChoices()
     }
+
+    await cache.set(MEMBER_ATTRIBUTES_CACHE_KEY, memberAttributes)
   }
 
   res.send(memberAttributes.choices)
@@ -603,10 +612,16 @@ export async function getMemberAttributes(req, res) {
  *
  * Unknown and read-only keys are ignored, so a client can safely send back the
  * whole member object it received.
+ *
+ * What changed is accumulated along the way and audited once at the end: a single
+ * request is a single entry in the trail, and a request that broke halfway leaves
+ * none.
  */
 export async function updateMember(req, res) {
   const user = req.rawUser
   const memberId = user._id
+  const previous = {}
+  const current = {}
 
   const wordpressChanges = Object.fromEntries(
     Object.keys(Wordpress.USER_OPTIONS)
@@ -648,11 +663,8 @@ export async function updateMember(req, res) {
 
     await Member.updateMemberRoles(memberId, roles)
 
-    Audit.logAuditTrail(req.user, 'MEMBER_UPDATE', {
-      memberId,
-      previous: {isAdmin: Boolean(user.profile?.isAdmin), roles: user.wordpressRoles},
-      current: {isAdmin: roles.includes('administrator'), roles}
-    })
+    Object.assign(previous, {isAdmin: Boolean(user.profile?.isAdmin), roles: user.wordpressRoles})
+    Object.assign(current, {isAdmin: roles.includes('administrator'), roles})
   }
 
   /* Identity, stored in WordPress core rather than in ACF */
@@ -671,13 +683,8 @@ export async function updateMember(req, res) {
 
     await Member.updateMemberProfile(memberId, profile)
 
-    if (!isEqual(previousProfile, profile)) {
-      Audit.logAuditTrail(req.user, 'MEMBER_UPDATE', {
-        memberId,
-        previous: previousProfile,
-        current: profile
-      })
-    }
+    Object.assign(previous, previousProfile)
+    Object.assign(current, profile)
   }
 
   /* Attributes stored in WordPress */
@@ -709,13 +716,8 @@ export async function updateMember(req, res) {
 
     await Member.updateWordpressOptions(memberId, options)
 
-    if (!isEqual(previousOptions, options)) {
-      Audit.logAuditTrail(req.user, 'MEMBER_UPDATE', {
-        memberId,
-        previous: previousOptions,
-        current: options
-      })
-    }
+    Object.assign(previous, previousOptions)
+    Object.assign(current, options)
   }
 
   /* Attributes stored on our side */
@@ -733,6 +735,10 @@ export async function updateMember(req, res) {
         badgeId
       })
     }
+  }
+
+  if (!isEqual(previous, current)) {
+    Audit.logAuditTrail(req.user, 'MEMBER_UPDATE', {memberId, previous, current})
   }
 
   res.send(await Member.getMemberById(memberId))

--- a/lib/api.js
+++ b/lib/api.js
@@ -704,12 +704,14 @@ export async function updateMember(req, res) {
     try {
       options = await Wordpress.updateUserOptions(user.wpUserId, wordpressChanges)
     } catch (error) {
-      // On a timeout we cannot tell whether WordPress applied the change or not.
-      // Resync so that what we display keeps matching what the shop enforces,
-      // then surface the original error to the caller.
-      await Member.syncWithWordpress(memberId).catch(syncError => {
-        console.debug('Unable to resync member after a failed update', syncError)
-      })
+      // When we cannot tell whether WordPress applied the change, resync so that
+      // what we display keeps matching what the shop enforces. On a refusal there
+      // is nothing to resync: WordPress wrote nothing.
+      if (Wordpress.isOutcomeUnknown(error)) {
+        await Member.syncWithWordpress(memberId).catch(syncError => {
+          console.debug('Unable to resync member after a failed update', syncError)
+        })
+      }
 
       throw error
     }

--- a/lib/api.js
+++ b/lib/api.js
@@ -574,14 +574,6 @@ export async function getMemberDevices(req, res) {
 }
 
 /**
- * Update the options owned by WordPress: bank transfer payment and reduced rate eligibility.
- *
- * WordPress is the source of truth here, because the shop reads these values live
- * at checkout (payment gateways and purchasable products). We therefore write to
- * WordPress first and only mirror into our own collection once it succeeded —
- * the other way around would display a value the shop ignores.
- */
-/**
  * Values allowed for the member attributes backed by a closed list.
  * They are defined in WordPress and cached here, so that clients can build their
  * dropdowns without knowing where the list comes from, and without paying a

--- a/lib/api.js
+++ b/lib/api.js
@@ -14,6 +14,7 @@ import * as Membership from './models/membership.js'
 import * as Purchase from './models/purchase.js'
 import * as Subscription from './models/subscription.js'
 import * as Ticket from './models/ticket.js'
+import * as Wordpress from './util/wordpress.js'
 import {isMacAddress, isValidDateOrPeriod} from './util/tools.js'
 
 function formatDate(date) {
@@ -570,6 +571,179 @@ export async function updateMemberMacAddresses(req, res) {
 export async function getMemberDevices(req, res) {
   const devices = await Device.getMemberDevices(req.rawUser._id)
   res.send(devices)
+}
+
+/**
+ * Update the options owned by WordPress: bank transfer payment and reduced rate eligibility.
+ *
+ * WordPress is the source of truth here, because the shop reads these values live
+ * at checkout (payment gateways and purchasable products). We therefore write to
+ * WordPress first and only mirror into our own collection once it succeeded —
+ * the other way around would display a value the shop ignores.
+ */
+/**
+ * Values allowed for the member attributes backed by a closed list.
+ * They are defined in WordPress and cached here, so that clients can build their
+ * dropdowns without knowing where the list comes from, and without paying a
+ * WordPress round-trip on every request.
+ */
+const MEMBER_ATTRIBUTES_TTL_IN_MS = 24 * 60 * 60 * 1000
+let memberAttributes = null
+
+export async function getMemberAttributes(req, res) {
+  if (!memberAttributes || Date.now() - memberAttributes.fetchedAt > MEMBER_ATTRIBUTES_TTL_IN_MS) {
+    memberAttributes = {
+      fetchedAt: Date.now(),
+      choices: await Wordpress.getUserOptionsChoices()
+    }
+  }
+
+  res.send(memberAttributes.choices)
+}
+
+/**
+ * Update a member.
+ *
+ * Callers send a flat member object and do not need to know where each field is
+ * actually stored: this is where we split them. Some attributes live in
+ * WordPress — the shop reads them live at checkout — and are written there
+ * first; the rest belongs to us.
+ *
+ * Unknown and read-only keys are ignored, so a client can safely send back the
+ * whole member object it received.
+ */
+export async function updateMember(req, res) {
+  const user = req.rawUser
+  const memberId = user._id
+
+  const wordpressChanges = Object.fromEntries(
+    Object.keys(Wordpress.USER_OPTIONS)
+      .filter(name => !isNil(req.body?.[name]))
+      .map(name => [name, req.body[name]])
+  )
+
+  const profileChanges = Object.fromEntries(
+    ['firstName', 'lastName']
+      .filter(name => !isNil(req.body?.[name]))
+      .map(name => [name, String(req.body[name])])
+  )
+
+  const hasBadgeChange = !isNil(req.body?.badgeId)
+  const hasAdminChange = !isNil(req.body?.isAdmin)
+    && Boolean(req.body.isAdmin) !== Boolean(user.profile?.isAdmin)
+
+  const hasChanges = Object.keys(wordpressChanges).length > 0
+    || Object.keys(profileChanges).length > 0
+    || hasBadgeChange
+    || hasAdminChange
+
+  if (!hasChanges) {
+    throw createHttpError(400, 'Aucun champ modifiable fourni')
+  }
+
+  /* Admin flag: it is a WordPress role, not a capability of ours */
+
+  if (hasAdminChange) {
+    if (!Member.isAdminRoleEditable(user)) {
+      throw createHttpError(
+        409,
+        'Le rôle de ce compte ne peut être changé que depuis WordPress'
+      )
+    }
+
+    const isAdmin = Boolean(req.body.isAdmin)
+    const roles = await Wordpress.updateUserRoles(user.wpUserId, [isAdmin ? 'administrator' : 'customer'])
+
+    await Member.updateMemberRoles(memberId, roles)
+
+    Audit.logAuditTrail(req.user, 'MEMBER_UPDATE', {
+      memberId,
+      previous: {isAdmin: Boolean(user.profile?.isAdmin), roles: user.wordpressRoles},
+      current: {isAdmin: roles.includes('administrator'), roles}
+    })
+  }
+
+  /* Identity, stored in WordPress core rather than in ACF */
+
+  if (Object.keys(profileChanges).length > 0) {
+    if (!user.wpUserId) {
+      throw createHttpError(409, 'Ce membre n\'a pas de compte WordPress associé')
+    }
+
+    const previousProfile = {
+      firstName: user.firstName ?? '',
+      lastName: user.lastName ?? ''
+    }
+
+    const profile = await Wordpress.updateUserProfile(user.wpUserId, profileChanges)
+
+    await Member.updateMemberProfile(memberId, profile)
+
+    if (!isEqual(previousProfile, profile)) {
+      Audit.logAuditTrail(req.user, 'MEMBER_UPDATE', {
+        memberId,
+        previous: previousProfile,
+        current: profile
+      })
+    }
+  }
+
+  /* Attributes stored in WordPress */
+
+  if (Object.keys(wordpressChanges).length > 0) {
+    if (!user.wpUserId) {
+      throw createHttpError(409, 'Ce membre n\'a pas de compte WordPress associé')
+    }
+
+    const previousOptions = {
+      ...Wordpress.formatUserOptions({}),
+      ...user.wordpressOptions
+    }
+
+    let options
+
+    try {
+      options = await Wordpress.updateUserOptions(user.wpUserId, wordpressChanges)
+    } catch (error) {
+      // On a timeout we cannot tell whether WordPress applied the change or not.
+      // Resync so that what we display keeps matching what the shop enforces,
+      // then surface the original error to the caller.
+      await Member.syncWithWordpress(memberId).catch(syncError => {
+        console.debug('Unable to resync member after a failed update', syncError)
+      })
+
+      throw error
+    }
+
+    await Member.updateWordpressOptions(memberId, options)
+
+    if (!isEqual(previousOptions, options)) {
+      Audit.logAuditTrail(req.user, 'MEMBER_UPDATE', {
+        memberId,
+        previous: previousOptions,
+        current: options
+      })
+    }
+  }
+
+  /* Attributes stored on our side */
+
+  if (hasBadgeChange) {
+    const {badgeId} = req.body
+    const previousBadgeId = user.badgeId
+
+    if (badgeId !== previousBadgeId) {
+      await Member.updateMemberBadge(memberId, badgeId)
+
+      Audit.logAuditTrail(req.user, 'MEMBER_BADGE_ID_UPDATE', {
+        memberId,
+        previousBadgeId,
+        badgeId
+      })
+    }
+  }
+
+  res.send(await Member.getMemberById(memberId))
 }
 
 export async function forceWordpressSync(req, res) {

--- a/lib/models/member.js
+++ b/lib/models/member.js
@@ -1,11 +1,11 @@
 import {differenceInMinutes, isSameDay, isValid, isWithinInterval, parseISO, setYear, sub} from 'date-fns'
-import {chain, maxBy, sumBy} from 'lodash-es'
+import {chain, isNil, maxBy, sumBy} from 'lodash-es'
 import {customAlphabet} from 'nanoid'
 import pMap from 'p-map'
 
 import cache from '../util/cache.js'
 import mongo from '../util/mongo.js'
-import {buildPictureUrl, buildPolaroidUrl, getAnonymousPictureUrl, getUser as getWpUser} from '../util/wordpress.js'
+import {buildPictureUrl, buildPolaroidUrl, formatUserOptions, getAnonymousPictureUrl, getUser as getWpUser} from '../util/wordpress.js'
 
 import {computeBalance} from '../calc.js'
 import renderDepletedBalance from '../emails/depleted-balance.js'
@@ -216,11 +216,11 @@ export async function syncWithWordpress(memberId) {
     first_name: firstName,
     last_name: lastName,
     trialDay,
-    acf: {
-      date_naissance: dateNaissance
-    },
+    acf,
     roles
   } = wpUser
+
+  const {date_naissance: dateNaissance} = acf
 
   await mongo.db.collection('users').updateOne(
     {_id: memberId},
@@ -233,7 +233,83 @@ export async function syncWithWordpress(memberId) {
           birthDate: new Date(dateNaissance).toISOString().slice(0, 10)
         }),
         trialDay,
+        // Mirror of the WordPress-owned options, WordPress stays the source of truth
+        wordpressOptions: formatUserOptions(acf),
+        // Kept to know whether the admin role can safely be toggled from here
+        wordpressRoles: roles,
         'profile.isAdmin': roles.includes('administrator')
+      }
+    }
+  )
+}
+
+/**
+ * Mirror the WordPress-owned options into our own collection.
+ * Only ever called *after* WordPress has accepted the change,
+ * so that we never display a value the shop would ignore.
+ *
+ * @param {string} memberId
+ * @param {{canPayByBankTransfer: boolean, isEligibleToReducedRate: boolean}} wordpressOptions
+ */
+/**
+ * Mirror the identity fields owned by WordPress core.
+ * Called after WordPress accepted the change, like updateWordpressOptions.
+ *
+ * @param {string} memberId
+ * @param {{firstName: string, lastName: string}} profile
+ */
+export async function updateMemberProfile(memberId, profile) {
+  return mongo.db.collection('users').updateOne(
+    {_id: memberId},
+    {$set: profile}
+  )
+}
+
+/**
+ * Roles between which the admin flag can be toggled from the manager.
+ * Restricted to accounts holding exactly one of them: several accounts combine
+ * `customer` with another role (`um_member`, `um_coworker`…), and switching
+ * those would silently drop the second one.
+ */
+const TOGGLEABLE_ADMIN_ROLES = new Set(['customer', 'administrator'])
+
+export function isAdminRoleEditable(user) {
+  const roles = user.wordpressRoles
+
+  return Boolean(user.wpUserId)
+    && Array.isArray(roles)
+    && roles.length === 1
+    && TOGGLEABLE_ADMIN_ROLES.has(roles[0])
+}
+
+/**
+ * Mirror the roles owned by WordPress, after it accepted the change.
+ *
+ * @param {string} memberId
+ * @param {string[]} roles
+ */
+export async function updateMemberRoles(memberId, roles) {
+  return mongo.db.collection('users').updateOne(
+    {_id: memberId},
+    {
+      $set: {
+        wordpressRoles: roles,
+        'profile.isAdmin': roles.includes('administrator')
+      }
+    }
+  )
+}
+
+export async function updateWordpressOptions(memberId, wordpressOptions) {
+  return mongo.db.collection('users').updateOne(
+    {_id: memberId},
+    {
+      $set: {
+        wordpressOptions,
+        // The birth date is also stored at the top level, under the historical
+        // name that syncWithWordpress writes and that the API exposes. Without
+        // this, it would keep showing the previous value until the next sync.
+        ...(isNil(wordpressOptions.birthDate) ? {} : {birthDate: wordpressOptions.birthDate})
       }
     }
   )
@@ -374,12 +450,24 @@ export async function computeMemberFromUser(user, options = {}) {
     email: user.email,
     badgeId: user.badgeId,
     isAdmin: user.profile.isAdmin,
+    // Whether the admin flag can be toggled from here, or only in WordPress
+    isAdminEditable: isAdminRoleEditable(user),
     balance: user.profile.balance,
     lastSeen: user.profile.heartbeat,
     location: user.profile.heartbeatLocation,
     picture: buildPictureUrl(user.wpUserId),
     thumbnail: buildPictureUrl(user.wpUserId, 'thumbnail'),
     polaroid: buildPolaroidUrl(user.wpUserId, 'big'),
+    // Stored in WordPress, mirrored here on sync. Clients do not need to know:
+    // PUT /api/members/:userId writes each attribute wherever it belongs.
+    // `birthDate` above comes from the same mirror, under its historical name.
+    canPayByBankTransfer: Boolean(user.wordpressOptions?.canPayByBankTransfer),
+    isEligibleToReducedRate: Boolean(user.wordpressOptions?.isEligibleToReducedRate),
+    isBoardCandidate: Boolean(user.wordpressOptions?.isBoardCandidate),
+    polaroidName: user.wordpressOptions?.polaroidName ?? '',
+    polaroidDescription: user.wordpressOptions?.polaroidDescription ?? '',
+    legalStatus: user.wordpressOptions?.legalStatus ?? '',
+    activityType: user.wordpressOptions?.activityType ?? '',
     attending: differenceInMinutes(new Date(), new Date(user.profile.heartbeat)) <= Device.LAST_SEEN_DELAY_IN_MIN
   }
 

--- a/lib/util/wordpress.js
+++ b/lib/util/wordpress.js
@@ -39,6 +39,21 @@ function rethrowWordPressError(error) {
   throw error
 }
 
+/**
+ * Whether a failed write leaves us unable to tell what WordPress actually did.
+ *
+ * A timeout or a WordPress-side failure can have been applied before we gave up,
+ * so our copy has to be resynced. A 4xx is unambiguous: WordPress refused the
+ * payload and wrote nothing.
+ *
+ * @param {Error} error as thrown by one of the update functions below
+ * @returns {boolean}
+ */
+export function isOutcomeUnknown(error) {
+  return error.code === 'ETIMEDOUT'
+    || (error.code === 'ERR_NON_2XX_3XX_RESPONSE' && error.response.statusCode >= 500)
+}
+
 export async function getOrders(year) {
   const orders = await got(`${WORDPRESS_BASE_URL}/api-json-wp/cowo/v1/commandes/${year}`, {
     username: WP_APIV2_USERNAME,

--- a/lib/util/wordpress.js
+++ b/lib/util/wordpress.js
@@ -11,6 +11,34 @@ const {
   PHOTOS_BASE_URL
 } = process.env
 
+/**
+ * Turn a WordPress 4xx into a proper HTTP error.
+ *
+ * WordPress validates what it receives (dates, allowed choices, roles) and answers
+ * 4xx with an explanatory message. got's HTTPError only carries the status under
+ * `response.statusCode`, so without this it reaches our error handler without a
+ * `statusCode` and gets served as a bare 500 — the manager would then only show
+ * "Une erreur inattendue est survenue." instead of the reason.
+ *
+ * @param {Error} error
+ * @throws always
+ */
+function rethrowWordPressError(error) {
+  const status = error.response?.statusCode
+
+  if (status >= 400 && status < 500) {
+    let message = error.response.body
+
+    try {
+      message = JSON.parse(error.response.body).message ?? message
+    } catch {}
+
+    throw createHttpError(status, message)
+  }
+
+  throw error
+}
+
 export async function getOrders(year) {
   const orders = await got(`${WORDPRESS_BASE_URL}/api-json-wp/cowo/v1/commandes/${year}`, {
     username: WP_APIV2_USERNAME,
@@ -77,7 +105,7 @@ export async function getUserOptionsChoices() {
     username: WP_APIV2_USERNAME,
     password: WP_APIV2_PASSWORD,
     timeout: {
-      request: 30_000
+      request: 10_000
     }
   }).json()
 
@@ -165,21 +193,7 @@ export async function updateUserProfile(wordpressUserId, profile) {
     timeout: {
       request: 30_000
     }
-  }).json().catch(error => {
-    const status = error.response?.statusCode
-
-    if (status && status >= 400 && status < 500) {
-      let message = error.response.body
-
-      try {
-        message = JSON.parse(error.response.body).message ?? message
-      } catch {}
-
-      throw createHttpError(status, message)
-    }
-
-    throw error
-  })
+  }).json().catch(rethrowWordPressError)
 
   return {
     firstName: updated.first_name ?? '',
@@ -202,21 +216,7 @@ export async function updateUserRoles(wordpressUserId, roles) {
     timeout: {
       request: 30_000
     }
-  }).json().catch(error => {
-    const status = error.response?.statusCode
-
-    if (status && status >= 400 && status < 500) {
-      let message = error.response.body
-
-      try {
-        message = JSON.parse(error.response.body).message ?? message
-      } catch {}
-
-      throw createHttpError(status, message)
-    }
-
-    throw error
-  })
+  }).json().catch(rethrowWordPressError)
 
   return updated.roles ?? []
 }

--- a/lib/util/wordpress.js
+++ b/lib/util/wordpress.js
@@ -1,5 +1,6 @@
 import process from 'node:process'
 import got from 'got'
+import createHttpError from 'http-errors'
 import {isNil} from 'lodash-es'
 
 const {
@@ -25,6 +26,199 @@ export async function getUser(userId) {
   }).json()
 
   return user
+}
+
+/**
+ * Options owned by WordPress, editable from the manager.
+ *
+ * They live in WordPress and stay there: several are read live by the shop
+ * (payment gateways, purchasable products) or by the exports. We only mirror
+ * them on our side for display.
+ *
+ * Maps our camelCase names to the ACF field names, with the expected type.
+ */
+export const USER_OPTIONS = {
+  canPayByBankTransfer: {acf: 'payer_en_virement', type: 'boolean'},
+  isEligibleToReducedRate: {acf: 'tarifs_reduits_ok', type: 'boolean'},
+  isBoardCandidate: {acf: 'candidat_au_ca', type: 'boolean'},
+  birthDate: {acf: 'date_naissance', type: 'string'}, // YYYY-MM-DD
+  polaroidName: {acf: 'polaroid_nom', type: 'string'},
+  polaroidDescription: {acf: 'polaroid_description', type: 'string'},
+  legalStatus: {acf: 'statut_juridique', type: 'string'},
+  activityType: {acf: 'type_activite', type: 'string'}
+}
+
+/**
+ * Translate an `acf` payload into our own naming.
+ *
+ * @param {Object} acf either the `acf` object of a WordPress user, or the
+ *   `values` object returned by the cowo/v1 options endpoint
+ * @returns {Object}
+ */
+export function formatUserOptions(acf = {}) {
+  return Object.fromEntries(
+    Object.entries(USER_OPTIONS).map(([name, {acf: field, type}]) => [
+      name,
+      type === 'boolean' ? Boolean(acf[field]) : (acf[field] ?? '')
+    ])
+  )
+}
+
+/**
+ * Values allowed for the options backed by a select.
+ * Reading them from WordPress avoids duplicating the list on our side and keeps
+ * it in sync when it is edited there. Callers are expected to cache the result:
+ * the list changes very rarely.
+ *
+ * @returns {Promise<{legalStatus: string[], activityType: string[]}>}
+ */
+export async function getUserOptionsChoices() {
+  const choices = await got(`${WORDPRESS_BASE_URL}/api-json-wp/cowo/v1/user-options/choices`, {
+    username: WP_APIV2_USERNAME,
+    password: WP_APIV2_PASSWORD,
+    timeout: {
+      request: 30_000
+    }
+  }).json()
+
+  return {
+    legalStatus: Object.keys(choices?.statut_juridique ?? {}),
+    activityType: Object.keys(choices?.type_activite ?? {})
+  }
+}
+
+/**
+ * Update the WordPress-side options of a member.
+ * Only the keys actually provided are sent, so a partial update stays partial.
+ *
+ * @param {number} wordpressUserId
+ * @param {Object} options subset of USER_OPTIONS keys
+ * @returns {Promise<Object>} the resulting state, as reported by WordPress
+ */
+export async function updateUserOptions(wordpressUserId, options) {
+  const payload = {}
+
+  for (const [name, {acf: field, type}] of Object.entries(USER_OPTIONS)) {
+    if (isNil(options[name])) {
+      continue
+    }
+
+    payload[field] = type === 'boolean' ? Boolean(options[name]) : String(options[name])
+  }
+
+  const {values} = await got.post(`${WORDPRESS_BASE_URL}/api-json-wp/cowo/v1/users/${wordpressUserId}/options`, {
+    username: WP_APIV2_USERNAME,
+    password: WP_APIV2_PASSWORD,
+    json: payload,
+    timeout: {
+      request: 30_000 // 30 seconds: WordPress can be slow on this endpoint
+    }
+  }).json().catch(error => {
+    // WordPress validates the values (dates, allowed choices) and answers 4xx with
+    // an explanatory message. Without this, got's HTTPError would surface as a bare
+    // 500 and the manager would only show "an unexpected error occurred".
+    const status = error.response?.statusCode
+
+    if (status && status >= 400 && status < 500) {
+      let message = error.response.body
+
+      try {
+        message = JSON.parse(error.response.body).message ?? message
+      } catch {}
+
+      throw createHttpError(status, message)
+    }
+
+    throw error
+  })
+
+  return formatUserOptions(values)
+}
+
+/**
+ * Update the identity fields of a WordPress user.
+ *
+ * Unlike the attributes above, these are not ACF fields: they live in WordPress
+ * core, so the standard REST endpoint is enough. It goes through wp_update_user(),
+ * which fires `profile_update` and therefore our own sync webhook — harmless,
+ * we refresh our copy right after anyway.
+ *
+ * @param {number} wordpressUserId
+ * @param {{firstName?: string, lastName?: string}} profile
+ * @returns {Promise<{firstName: string, lastName: string}>}
+ */
+export async function updateUserProfile(wordpressUserId, profile) {
+  const payload = {}
+
+  if (!isNil(profile.firstName)) {
+    payload.first_name = String(profile.firstName)
+  }
+
+  if (!isNil(profile.lastName)) {
+    payload.last_name = String(profile.lastName)
+  }
+
+  const updated = await got.post(`${WORDPRESS_BASE_URL}/api-json-wp/wp/v2/users/${wordpressUserId}`, {
+    username: WP_APIV2_USERNAME,
+    password: WP_APIV2_PASSWORD,
+    json: payload,
+    timeout: {
+      request: 30_000
+    }
+  }).json().catch(error => {
+    const status = error.response?.statusCode
+
+    if (status && status >= 400 && status < 500) {
+      let message = error.response.body
+
+      try {
+        message = JSON.parse(error.response.body).message ?? message
+      } catch {}
+
+      throw createHttpError(status, message)
+    }
+
+    throw error
+  })
+
+  return {
+    firstName: updated.first_name ?? '',
+    lastName: updated.last_name ?? ''
+  }
+}
+
+/**
+ * Replace the roles of a WordPress user.
+ *
+ * @param {number} wordpressUserId
+ * @param {string[]} roles
+ * @returns {Promise<string[]>} the resulting roles
+ */
+export async function updateUserRoles(wordpressUserId, roles) {
+  const updated = await got.post(`${WORDPRESS_BASE_URL}/api-json-wp/wp/v2/users/${wordpressUserId}`, {
+    username: WP_APIV2_USERNAME,
+    password: WP_APIV2_PASSWORD,
+    json: {roles},
+    timeout: {
+      request: 30_000
+    }
+  }).json().catch(error => {
+    const status = error.response?.statusCode
+
+    if (status && status >= 400 && status < 500) {
+      let message = error.response.body
+
+      try {
+        message = JSON.parse(error.response.body).message ?? message
+      } catch {}
+
+      throw createHttpError(status, message)
+    }
+
+    throw error
+  })
+
+  return updated.roles ?? []
 }
 
 export function getUserFromOAuthAccessToken(accessToken) {

--- a/server.js
+++ b/server.js
@@ -43,6 +43,7 @@ import {
   getMemberMemberships,
   getMemberSubscriptions,
   getMemberTicketsOrders,
+  getMemberAttributes,
   getUsersStats,
   getVotingMembers,
   heartbeat,
@@ -60,6 +61,7 @@ import {
   updateMemberMembership,
   updateMemberSubscription,
   updateMemberTicketsOrder,
+  updateMember,
   updatePresence,
   addMemberSubscription
 } from './lib/api.js'
@@ -114,7 +116,10 @@ app.get('/coworkersNow', w(coworkersNow)) // Legacy
 /* General purpose */
 
 app.get('/api/members', w(multiAuth), w(ensureAdmin), w(getAllMembers))
+// Declared before /:userId, otherwise the param route would capture "attributes"
+app.get('/api/members/attributes', w(multiAuth), w(ensureAdmin), w(getMemberAttributes))
 app.get('/api/members/:userId', w(multiAuth), w(ensureAccess), w(getMemberInfos))
+app.put('/api/members/:userId', express.json(), w(multiAuth), w(ensureAdmin), w(updateMember))
 app.get('/api/members/:userId/audit', w(multiAuth), w(ensureAdmin), w(getMemberAuditTrail))
 
 app.get('/api/members/:userId/activity', w(multiAuth), w(ensureAccess), w(getMemberActivityCoverage))


### PR DESCRIPTION
WordPress demeure la source de référence pour les attributs qu'il gère, car le site WP les consulte en temps réel pour afficher des choses, autoriser des actions, etc. Et ces infos on encore vocation a être modifiées depuis le dashboard Wordpress.
Il serai plus pratique de pouvoir gérer ces attributs depuis manager tout en gardant la synchro avec wordpress sans perte de cohérence. 

Exemple : le booleen "Cette personne est éligible aux tarifs réduits sur les abonnements et tickets" peut être modifié dans WP, il devrait pouvoir l'etre dans WP aussi.

Pour y parvenir, j'ai mis en place les deux routes ci-dessous : 

 * Ajout de la route `PUT /api/members/:userId`, une route unique permettant d'envoyer un objet « membre » pour faire des mises à jour a la fois dans mongo et dans WordPress. Les clients qui appellent la route ignorent donc où sont effectivement stockées les infos, juste, elles sont mises à jours par le backend dans mongo, ou wordpress, (ou les deux si nécéssaire).

 * Ajout de la route `GET /api/members/attributes`, qui renvoie les valeurs autorisées pour les champs select (comme type de poste). Ces valeurs proviennent de Wordpress (dans la définition ACF) et sont mises en cache pour une durée d'un jour afin d'éviter d'interroger WordPress à chaque consultation d'une page de membre.